### PR TITLE
Rework math utils

### DIFF
--- a/crates/eldenring-util/src/ez_draw.rs
+++ b/crates/eldenring-util/src/ez_draw.rs
@@ -3,13 +3,13 @@ use eldenring::{
     position::{HavokPosition, PositionDelta},
 };
 use pelite::pe64::Pe;
-use shared::FSVector4;
+use shared::F32Vector4;
 
 use crate::{program::Program, rva};
 
 pub trait CSEzDrawExt {
     /// Set the color for the to-be-rendered primitives.
-    fn set_color(&self, color: &FSVector4);
+    fn set_color(&self, color: &F32Vector4);
 
     fn draw_line(&self, from: &HavokPosition, to: &HavokPosition);
 
@@ -27,7 +27,7 @@ pub trait CSEzDrawExt {
     );
 }
 
-type FnSetColor = extern "C" fn(*const CSEzDraw, *const FSVector4);
+type FnSetColor = extern "C" fn(*const CSEzDraw, *const F32Vector4);
 type FnDrawLine = extern "C" fn(*const CSEzDraw, *const HavokPosition, *const HavokPosition);
 type FnDrawCapsule =
     extern "C" fn(*const CSEzDraw, *const HavokPosition, *const HavokPosition, f32);
@@ -36,7 +36,7 @@ type FnDrawFan =
     extern "C" fn(*const CSEzDraw, *const HavokPosition, *const HavokPosition, f32, f32, f32);
 
 impl CSEzDrawExt for CSEzDraw {
-    fn set_color(&self, color: &FSVector4) {
+    fn set_color(&self, color: &F32Vector4) {
         let target = unsafe {
             std::mem::transmute::<u64, FnSetColor>(
                 Program::current()

--- a/crates/eldenring-util/src/world_chr_man.rs
+++ b/crates/eldenring-util/src/world_chr_man.rs
@@ -1,5 +1,5 @@
 use eldenring::cs::{ChrIns, FieldInsHandle, WorldChrMan};
-use shared::FSVector4;
+use shared::F32Vector4;
 
 pub trait WorldChrManExt {
     fn chr_ins_by_handle(&mut self, handle: &FieldInsHandle) -> Option<&mut ChrIns>;
@@ -33,7 +33,7 @@ impl WorldChrManExt for WorldChrMan {
         self.debug_chr_creator.init_data.talk_id = request.talk_id;
 
         self.debug_chr_creator.init_data.spawn_position =
-            FSVector4(request.pos_x, request.pos_y, request.pos_z, 0.0);
+            F32Vector4(request.pos_x, request.pos_y, request.pos_z, 0.0);
 
         self.debug_chr_creator.spawn = true;
     }

--- a/crates/eldenring/src/cs/bullet_manager.rs
+++ b/crates/eldenring/src/cs/bullet_manager.rs
@@ -1,6 +1,6 @@
 use std::ptr::NonNull;
 
-use shared::{FSVector4, OwnedPtr};
+use shared::{F32Vector4, OwnedPtr};
 
 use super::{CSBulletIns, ChrCam, FieldInsHandle};
 
@@ -119,16 +119,16 @@ pub struct BulletSpawnData {
     target: FieldInsHandle,
     unk28: u32,
     unk2c: u32,
-    unk30: FSVector4,
+    unk30: F32Vector4,
     unk40: u32,
     unk44: u32,
     pad48: [u8; 8],
     /// Forward vector, only applies if angle vec is 0?
-    acceleration_angle: FSVector4,
-    unk60: FSVector4,
+    acceleration_angle: F32Vector4,
+    unk60: F32Vector4,
     /// Forward vector
-    angle: FSVector4,
-    position: FSVector4,
+    angle: F32Vector4,
+    position: F32Vector4,
     unk90: u64,
     unk98: u64,
     unka0: u64,

--- a/crates/eldenring/src/cs/camera.rs
+++ b/crates/eldenring/src/cs/camera.rs
@@ -1,6 +1,6 @@
 use std::ptr::NonNull;
 
-use shared::{FSMatrix4x4, FSVector4, OwnedPtr};
+use shared::{F32Matrix4x4, F32Vector4, OwnedPtr};
 
 use super::ChrIns;
 
@@ -32,7 +32,7 @@ pub struct CSCam {
     vftable: usize,
     unk8: u32,
     unkc: u32,
-    pub matrix: FSMatrix4x4,
+    pub matrix: F32Matrix4x4,
     pub fov: f32,
     pub aspect_ratio: f32,
     pub near_plane: f32,
@@ -53,8 +53,8 @@ pub struct ChrCam {
     unk79: [u8; 0x3],
     pub camera_type: ChrCamType,
     unk80: [u8; 0xc],
-    pub pad_accelleration: FSVector4,
-    pub move_accelleration: FSVector4,
+    pub pad_accelleration: F32Vector4,
+    pub move_accelleration: F32Vector4,
     unkb0: f32,
     pub is_movement_locked: bool,
     unkb5: [u8; 0x11b],

--- a/crates/eldenring/src/cs/chr_ins.rs
+++ b/crates/eldenring/src/cs/chr_ins.rs
@@ -13,7 +13,7 @@ use crate::param::ATK_PARAM_ST;
 use crate::position::{BlockPosition, HavokPosition};
 use crate::rotation::Quaternion;
 use crate::Vector;
-use shared::{FSMatrix4x4, FSVector4, OwnedPtr};
+use shared::{F32Matrix4x4, F32Vector4, OwnedPtr};
 
 use crate::cs::field_ins::{FieldInsBaseVmt, FieldInsHandle};
 use crate::cs::gaitem::GaitemHandle;
@@ -99,11 +99,11 @@ pub struct ChrIns {
     pub p2p_entity_handle: P2PEntityHandle,
     unk78: usize,
     /// Position in global map chunk coordinates.
-    pub chunk_position: FSVector4,
+    pub chunk_position: F32Vector4,
     /// Initial position of the character when it was created.
     pub initial_position: HavokPosition,
     /// Initial orientation of the character when it was created (in euler angles).
-    pub initial_orientation_euler: FSVector4,
+    pub initial_orientation_euler: F32Vector4,
     /// Time in seconds since last update ran for the ChrIns.
     pub chr_update_delta_time: f32,
     pub omission_mode: OmissionMode,
@@ -115,7 +115,7 @@ pub struct ChrIns {
     unkc8: u8,
     pub is_locked_on: bool,
     unkca: [u8; 0x6],
-    pub lock_on_target_position: FSVector4,
+    pub lock_on_target_position: F32Vector4,
     unke0: [u8; 0x80],
     /// Used by TAE's UseGoods to figure out what item to actually apply.
     pub tae_queued_use_item: ItemId,
@@ -150,7 +150,7 @@ pub struct ChrIns {
     pub chr_flags1ca: ChrInsFlags1ca,
     // _pad1cb: u8,
     pub chr_flags1cc: ChrInsFlags1cc,
-    unk1d0: FSVector4,
+    unk1d0: F32Vector4,
     unk1e0: u32,
     pub network_authority: u32,
     pub event_entity_id: u32,
@@ -733,22 +733,22 @@ pub struct CSChrPhysicsModule {
     unkc8: f32,
     pub adjust_to_hi_collision: bool,
     unkcd: [u8; 0x3],
-    root_motion: FSVector4,
-    root_motion_unk: FSVector4,
-    unkf0: FSVector4,
+    root_motion: F32Vector4,
+    root_motion_unk: F32Vector4,
+    unkf0: F32Vector4,
     unk100: [u8; 0x4],
     pub chr_push_up_factor: f32,
     ground_offset: f32,
     ground_offset_unk: f32,
     unk110: [u8; 0x10],
-    gravity: FSVector4,
-    gravity_unk: FSVector4,
+    gravity: F32Vector4,
+    gravity_unk: F32Vector4,
     unk140: [u8; 0x10],
-    unk150: FSVector4,
-    unk160: FSVector4,
-    unk170: FSVector4,
-    unk180: FSVector4,
-    pub additional_rotation: FSVector4,
+    unk150: F32Vector4,
+    unk160: F32Vector4,
+    unk170: F32Vector4,
+    unk180: F32Vector4,
+    pub additional_rotation: F32Vector4,
     unk1a0: [u8; 0x8],
     unk1a8: FD4Time,
     unk1b8: f32,
@@ -785,8 +785,8 @@ pub struct CSChrPhysicsModule {
     /// Information about character's sliding state
     pub slide_info: ChrPhysicsSlideInfo,
     unk290: [u8; 0x30],
-    unkposition: FSVector4,
-    pub orientation_euler: FSVector4,
+    unkposition: F32Vector4,
+    pub orientation_euler: F32Vector4,
     pub chr_hit_height: f32,
     pub chr_hit_radius: f32,
     unk2e8: [u8; 0x8],
@@ -813,10 +813,10 @@ pub struct CSChrPhysicsModule {
     hk_frame_data: usize,
     unk398: f32,
     unk39c: [u8; 0x4],
-    unk3a0: FSVector4,
+    unk3a0: F32Vector4,
     unk3b0: [u8; 0x10],
-    unk3c0: FSVector4,
-    unk3d0: FSVector4,
+    unk3c0: F32Vector4,
+    unk3d0: F32Vector4,
     unk3e0: [u8; 0x6],
     /// Loaded from NpcParam
     pub is_enable_step_disp_interpolate: bool,
@@ -846,21 +846,21 @@ bitfield! {
 
 #[repr(C)]
 pub struct ChrPhysicsSlopeInfo {
-    unk0: FSVector4,
-    unk10: FSVector4,
+    unk0: F32Vector4,
+    unk10: F32Vector4,
     unk20: f32,
     unk24: f32,
     unk28: f32,
     unk2c: f32,
-    unk30: FSVector4,
+    unk30: F32Vector4,
     /// Slope vector, used for slope detection.
-    pub slope_vector: FSVector4,
+    pub slope_vector: F32Vector4,
     unk50: [u8; 0x20],
 }
 #[repr(C)]
 pub struct ChrPhysicsSlideInfo {
     /// Slide direction vector
-    pub slide_vector: FSVector4,
+    pub slide_vector: F32Vector4,
     /// Information about the slope the character is sliding on
     pub slope_info: NonNull<ChrPhysicsSlopeInfo>,
     /// Angle at which the character is starting to slide
@@ -961,7 +961,7 @@ pub struct CSChrBehaviorModule {
     unk18: usize,
     unk20: usize,
     unk28: usize,
-    pub root_motion: FSVector4,
+    pub root_motion: F32Vector4,
     unk40: [u8; 0x20],
     unk60: [u8; 0xa48],
     unkaa8: [u8; 0x58],
@@ -977,7 +977,7 @@ pub struct CSChrBehaviorModule {
     /// Read from NpcParam, PI by default.
     pub max_ankle_roll_angle_rad: f32,
     unk168c: [u8; 0x104],
-    unk1790: FSVector4,
+    unk1790: F32Vector4,
     unk17a0: [u8; 0x10],
     chr_behavior_debug_anim_helper: usize,
     unk17b8: [u8; 0x10],
@@ -1094,8 +1094,8 @@ pub struct CSPairAnimNode {
     unk8: usize,
     pub owner: OwnedPtr<ChrIns>,
     pub forwarding_recipient: FieldInsHandle,
-    unk20: FSVector4,
-    unk30: FSVector4,
+    unk20: F32Vector4,
+    unk30: F32Vector4,
     unk40: u32,
     unk44: [u8; 0xc],
 }
@@ -1175,8 +1175,8 @@ pub struct ChrCtrl {
     pub flags_copy: ChrCtrlFlags,
     unkf8: u32,
     pub chr_proxy_flags: ChrCtrlChrProxyFlags,
-    unk100: FSVector4,
-    unk110: FSVector4,
+    unk100: F32Vector4,
+    unk110: F32Vector4,
     unk120: [u8; 0x8],
     pub chr_ragdoll_state: u8,
     // _pad129: [u8; 0x3],
@@ -1189,12 +1189,12 @@ pub struct ChrCtrl {
     unk190: [u8; 0x10],
     /// Offset from the character's dmypoly for the tag position (name, hp, etc).
     /// Will modify position of the resulting tag.
-    pub lock_on_chr_tag_dmypoly_offset: FSVector4,
+    pub lock_on_chr_tag_dmypoly_offset: F32Vector4,
     /// Stores the model matrix derived from `CSChrPhysicsModule::ConstructModelMatrix`.
     /// Constructed from `CSChrPhysicsModule::position` and `CSChrPhysicsModule::orientation`.
-    pub physics_model_matrix: FSMatrix4x4,
+    pub physics_model_matrix: F32Matrix4x4,
     /// Stores the `raw_physics_model_matrix` multiplied by itself.
-    pub physics_transform_matrix_squared: FSMatrix4x4,
+    pub physics_transform_matrix_squared: F32Matrix4x4,
     /// The primary model matrix for the character.
     /// It's initially constructed by combining:
     /// - Translation from `raw_physics_model_matrix` and `vertical_position_offset`.
@@ -1204,14 +1204,14 @@ pub struct ChrCtrl {
     /// This matrix is then processed by ChrEasingModule,
     /// and the eased result is stored back into this field. It's the final matrix
     /// propagated to components like `locationMtx44ChrEntity`.
-    pub model_matrix: FSMatrix4x4,
-    /// Stores the `model_matrix` multiplied by itself after all modifications.
-    pub model_matrix_squared: FSMatrix4x4,
-    unk2b0: FSVector4,
+    pub model_matrix: F32Matrix4x4,
+    /// Stores the `model_matrix` multiplied by itself after all modifications.chr_ins
+    pub model_matrix_squared: F32Matrix4x4,
+    unk2b0: F32Vector4,
     /// An additional orientation (quaternion) that is multiplied with the orientation
     /// derived from the `raw_physics_model_matrix` to produce the final orientation
     /// for the `model_matrix`.
-    pub additional_orientation_quat: FSVector4,
+    pub additional_orientation_quat: F32Vector4,
     /// An offset applied to the Y-component (vertical) of the character's position
     /// when constructing the translation part of the `model_matrix`.
     pub vertical_position_offset: f32,
@@ -1260,10 +1260,10 @@ pub struct ChrCtrl {
     /// Fetched from NpcParam
     pub undulation_correction_gain: f32,
     unk33c: [u8; 0x14],
-    unk350: FSVector4,
-    unk360: FSVector4,
+    unk350: F32Vector4,
+    unk360: F32Vector4,
     unk370: [u8; 0x10],
-    unk380: FSVector4,
+    unk380: F32Vector4,
     unk390: [u8; 0x19],
     /// Group, deciding how character will collide with other characters.
     /// Fetched from NpcParam

--- a/crates/eldenring/src/cs/event_flag.rs
+++ b/crates/eldenring/src/cs/event_flag.rs
@@ -1,7 +1,7 @@
 use std::mem::ManuallyDrop;
 
 use crate::Tree;
-use shared::{FSVector4, OwnedPtr};
+use shared::{F32Vector4, OwnedPtr};
 
 pub struct EventFlag(u32);
 

--- a/crates/eldenring/src/cs/fe_man.rs
+++ b/crates/eldenring/src/cs/fe_man.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, ptr::NonNull};
 
 use crate::{dltx::DLString, CSFixedList};
-use shared::{FSVector4, OwnedPtr};
+use shared::{F32Vector4, OwnedPtr};
 
 use super::{CSMenuManImp, FieldInsHandle};
 
@@ -42,7 +42,7 @@ pub struct CSFeManImp {
     /// Wraps around when it reaches 6
     pub proc_status_messages_write_index: u32,
     unk59c4: [u8; 12],
-    unk59d0: FSVector4,
+    unk59d0: F32Vector4,
     unk59e0: u32,
     unk59e4: [u8; 12],
     /// Data used for the enemy character tags
@@ -342,7 +342,7 @@ pub struct ChrFriendTagEntry {
     /// X, Y - screen position
     /// Z - depth, seems to be increased when character is further away, not used elsewhere
     /// W - unused, always 0
-    pub screen_pos: FSVector4,
+    pub screen_pos: F32Vector4,
     /// Should tag be visible on screen?
     pub is_visible: bool,
     /// Is line of sight to this character blocked?
@@ -409,7 +409,7 @@ pub struct ChrEnemyTagEntry {
     /// X, Y - screen position
     /// Z - depth, seems to be increased when character is further away, not used elsewhere
     /// W - unused, always 0
-    pub screen_pos: FSVector4,
+    pub screen_pos: F32Vector4,
     unk20: [u8; 0x4],
     /// Amount of hp lost
     /// Used to render the damage number on the tag

--- a/crates/eldenring/src/cs/session_manager.rs
+++ b/crates/eldenring/src/cs/session_manager.rs
@@ -9,7 +9,7 @@ use crate::{
     fd4::FD4Time,
     DoublyLinkedList, Vector,
 };
-use shared::{FSVector3, FSVector4, OwnedPtr};
+use shared::{F32Vector3, F32Vector4, OwnedPtr};
 
 use super::{BlockId, CSEzTask, CSEzUpdateTask, P2PEntityHandle};
 
@@ -225,7 +225,7 @@ pub struct CSStayInMultiplayAreaWarpData {
     stay_in_multiplay_area_warp_step: [u8; 0xc8],
     /// Last position player was before stepping out of the multiplay area, relative to the map.
     /// Read from GameMan and uses same logic as bloodstains.
-    pub saved_position: FSVector3,
+    pub saved_position: F32Vector3,
     /// Last BlockId player was before stepping out of the multiplay area.
     /// Read from GameMan and uses same logic as bloodstains.
     pub saved_block_id: BlockId,

--- a/crates/eldenring/src/cs/sfx.rs
+++ b/crates/eldenring/src/cs/sfx.rs
@@ -1,6 +1,6 @@
 use crate::gxffx::GXFfxSceneCtrl;
 use crate::{Tree, Vector};
-use shared::{FSMatrix4x4, OwnedPtr};
+use shared::{F32Matrix4x4, OwnedPtr};
 
 #[repr(C)]
 /// Source of name: RTTI

--- a/crates/eldenring/src/cs/sos_sign_man.rs
+++ b/crates/eldenring/src/cs/sos_sign_man.rs
@@ -6,7 +6,7 @@ use crate::dltx::DLString;
 use crate::fd4::FD4Time;
 use crate::{stl::DoublyLinkedList, Tree, Vector};
 
-use shared::FSVector3;
+use shared::F32Vector3;
 
 use shared::OwnedPtr;
 
@@ -110,7 +110,7 @@ pub struct SosSignData {
     /// Block ID where the sign was placed
     pub block_id: BlockId,
     /// Position of the sign (in physics space)
-    pub pos: FSVector3,
+    pub pos: F32Vector3,
     /// Rotation of the sign
     pub yaw: f32,
     pub play_region_id: u32,
@@ -214,10 +214,10 @@ pub struct PhantomJoinData {
     /// ID of the event flag that will be set when the NPC sign is dismissed
     pub dismissal_event_flag_id: u32,
     /// Position where phantom will be summoned (in physics space)
-    pub pos: FSVector3,
+    pub pos: F32Vector3,
     /// Rotation for the phantom
     /// This is the same as the sign's rotation if phantom is joining by a sign
-    pub rotation: FSVector3,
+    pub rotation: F32Vector3,
     pub block_id: BlockId,
     /// Player id of the sign owner from the server
     /// 1 if the sign is NPC

--- a/crates/eldenring/src/cs/targeting.rs
+++ b/crates/eldenring/src/cs/targeting.rs
@@ -3,7 +3,7 @@ use vtable_rs::VPtr;
 
 use crate::position::HavokPosition;
 use crate::rotation::Quaternion;
-use shared::FSVector4;
+use shared::F32Vector4;
 
 use super::{CSBulletIns, ChrIns, FieldInsHandle, SpecialEffect};
 
@@ -45,9 +45,9 @@ pub trait CSTargetingSystemOwnerVmt {
 
     fn get_orientation<'a>(&self, out: &'a mut Quaternion) -> &'a mut Quaternion;
 
-    fn get_forward<'a>(&self, out: &'a mut FSVector4) -> &'a mut FSVector4;
+    fn get_forward<'a>(&self, out: &'a mut F32Vector4) -> &'a mut F32Vector4;
 
-    fn get_forward2<'a>(&self, out: &'a mut FSVector4) -> &'a mut FSVector4;
+    fn get_forward2<'a>(&self, out: &'a mut F32Vector4) -> &'a mut F32Vector4;
 
     fn get_hit_height(&self) -> f32;
 
@@ -104,7 +104,7 @@ pub trait CSTargetingSystemOwnerVmt {
 
     fn unk108(&self) -> u8;
 
-    fn unk110<'a>(&self, out: &'a mut FSVector4) -> &'a mut FSVector4;
+    fn unk110<'a>(&self, out: &'a mut F32Vector4) -> &'a mut F32Vector4;
 
     fn get_hearing_head_size(&self) -> f32;
 

--- a/crates/eldenring/src/cs/world_chr_man.rs
+++ b/crates/eldenring/src/cs/world_chr_man.rs
@@ -8,7 +8,7 @@ use vtable_rs::VPtr;
 
 use crate::Tree;
 use crate::{cs::ChrIns, Vector};
-use shared::{FSMatrix4x4, FSVector4, OwnedPtr};
+use shared::{F32Matrix4x4, F32Vector4, OwnedPtr};
 
 use super::{BlockId, ChrCam, FieldInsHandle, NetChrSync, PlayerIns};
 
@@ -126,10 +126,10 @@ pub struct CSDebugChrCreator {
 
 #[repr(C)]
 pub struct CSDebugChrCreatorInitData {
-    pub spawn_position: FSVector4,
-    spawn_rotation: FSVector4,
-    unk20: FSVector4,
-    spawn_scale: FSVector4,
+    pub spawn_position: F32Vector4,
+    spawn_rotation: F32Vector4,
+    unk20: F32Vector4,
+    spawn_scale: F32Vector4,
     pub npc_param_id: i32,
     pub npc_think_param_id: i32,
     pub event_entity_id: i32,
@@ -379,7 +379,7 @@ pub struct SummonBuddyManager {
     unk94: u32,
     unk98: u32,
     unk9c: u32,
-    unka0: FSVector4,
+    unka0: F32Vector4,
     unkb0: f32,
     unkb4: u32,
     unkb8: u32,

--- a/crates/eldenring/src/rotation.rs
+++ b/crates/eldenring/src/rotation.rs
@@ -1,7 +1,7 @@
 use nalgebra_glm as glm;
 use std::fmt::Display;
 
-use shared::FSVector4;
+use shared::F32Vector4;
 
 #[repr(C, align(16))]
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/shared/src/matrix.rs
+++ b/crates/shared/src/matrix.rs
@@ -1,18 +1,33 @@
 /// Defines some helper methods around dealing with math
-use std::ops::{Add, Mul, Sub};
+use std::ops::{Add, Sub};
 
-use nalgebra::RowVector4;
-use nalgebra_glm::{Mat4, Vec3};
+pub trait MatrixLayout {}
+
+pub enum RowMajor {}
+impl MatrixLayout for RowMajor {}
+
+pub enum ColMajor {}
+impl MatrixLayout for ColMajor {}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct F32Matrix4x4<L: MatrixLayout = RowMajor>(
+    pub F32Vector4,
+    pub F32Vector4,
+    pub F32Vector4,
+    pub F32Vector4,
+    std::marker::PhantomData<L>,
+);
 
 #[repr(C, align(16))]
 #[derive(Debug, Clone, Copy)]
-pub struct FSVector4(pub f32, pub f32, pub f32, pub f32);
+pub struct F32Vector4(pub f32, pub f32, pub f32, pub f32);
 
-impl Sub<FSVector4> for FSVector4 {
-    type Output = FSVector4;
+impl Sub<F32Vector4> for F32Vector4 {
+    type Output = F32Vector4;
 
-    fn sub(self, rhs: FSVector4) -> Self::Output {
-        FSVector4(
+    fn sub(self, rhs: F32Vector4) -> Self::Output {
+        F32Vector4(
             self.0 - rhs.0,
             self.1 - rhs.1,
             self.2 - rhs.2,
@@ -21,11 +36,11 @@ impl Sub<FSVector4> for FSVector4 {
     }
 }
 
-impl Add<FSVector4> for FSVector4 {
-    type Output = FSVector4;
+impl Add<F32Vector4> for F32Vector4 {
+    type Output = F32Vector4;
 
-    fn add(self, rhs: FSVector4) -> Self::Output {
-        FSVector4(
+    fn add(self, rhs: F32Vector4) -> Self::Output {
+        F32Vector4(
             self.0 - rhs.0,
             self.1 - rhs.1,
             self.2 - rhs.2,
@@ -36,45 +51,4 @@ impl Add<FSVector4> for FSVector4 {
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
-pub struct FSVector3(pub f32, pub f32, pub f32);
-impl From<FSVector3> for Vec3 {
-    fn from(val: FSVector3) -> Self {
-        Vec3::new(val.0, val.1, val.2)
-    }
-}
-
-#[repr(C)]
-#[derive(Debug, Clone)]
-pub struct FSMatrix4x4(pub FSVector4, pub FSVector4, pub FSVector4, pub FSVector4);
-
-impl From<FSMatrix4x4> for Mat4 {
-    fn from(val: FSMatrix4x4) -> Self {
-        Mat4::from_rows(&[
-            RowVector4::new(val.0 .0, val.0 .1, val.0 .2, val.0 .3),
-            RowVector4::new(val.1 .0, val.1 .1, val.1 .2, val.1 .3),
-            RowVector4::new(val.2 .0, val.2 .1, val.2 .2, val.2 .3),
-            RowVector4::new(val.3 .0, val.3 .1, val.3 .2, val.3 .3),
-        ])
-    }
-}
-
-impl From<Mat4> for FSMatrix4x4 {
-    fn from(value: Mat4) -> Self {
-        Self(
-            FSVector4(value.m11, value.m12, value.m13, value.m14),
-            FSVector4(value.m21, value.m22, value.m23, value.m24),
-            FSVector4(value.m31, value.m32, value.m33, value.m34),
-            FSVector4(value.m41, value.m42, value.m43, value.m44),
-        )
-    }
-}
-
-impl Mul<Mat4> for FSMatrix4x4 {
-    type Output = FSMatrix4x4;
-
-    fn mul(self, rhs: Mat4) -> Self::Output {
-        let lhs: Mat4 = self.clone().into();
-
-        (lhs * rhs).into()
-    }
-}
+pub struct F32Vector3(pub f32, pub f32, pub f32);

--- a/examples/debug-line/src/lib.rs
+++ b/examples/debug-line/src/lib.rs
@@ -10,7 +10,7 @@ use eldenring_util::{
     task::CSTaskImpExt,
 };
 
-use shared::FSVector4;
+use shared::F32Vector4;
 
 use nalgebra_glm as glm;
 
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn DllMain(_hmodule: usize, reason: u32) -> bool {
                 };
 
                 // Set color for the to-be-rendered line.
-                ez_draw.set_color(&FSVector4(0.0, 0.0, 1.0, 1.0));
+                ez_draw.set_color(&F32Vector4(0.0, 0.0, 1.0, 1.0));
 
                 // Draw the line from the players position to a meter in front of the player.
                 ez_draw.draw_line(

--- a/tools/debug/src/display/shared.rs
+++ b/tools/debug/src/display/shared.rs
@@ -1,9 +1,9 @@
 use hudhook::imgui::Ui;
-use shared::{FSMatrix4x4, FSVector4};
+use shared::{F32Matrix4x4, F32Vector4};
 
 use super::DebugDisplay;
 
-impl DebugDisplay for FSMatrix4x4 {
+impl DebugDisplay for F32Matrix4x4 {
     fn render_debug(&self, ui: &&mut Ui) {
         self.0.render_debug(ui);
         ui.separator();
@@ -16,7 +16,7 @@ impl DebugDisplay for FSMatrix4x4 {
     }
 }
 
-impl DebugDisplay for FSVector4 {
+impl DebugDisplay for F32Vector4 {
     fn render_debug(&self, ui: &&mut Ui) {
         ui.text(format!("x: {}", self.0));
         ui.text(format!("y: {}", self.1));


### PR DESCRIPTION
Rename FS matrix/vector types to F32 instead, add notion of row and col major to the Matrix4x4 type.

Removes nalgebra bindings in the process.
The reason for this is to stop forcing people to pick a matching version of nalgebra, the idea is to move most common operations into the library later without exposing any part of nalgebra or nalgebra-glm.