### PR TITLE
Support mapping vftable RVA in binary-mapper

### DIFF
--- a/tools/binary-mapper/README.md
+++ b/tools/binary-mapper/README.md
@@ -63,6 +63,7 @@ Patterns can also be located using RTTI information embedded in the executable t
 [[vmts]]
 class = "DLUID::MouseDevice<DLKR::DLMultiThreadingPolicy>"
 captures = { "MOUSE_DEVICE_SHOULD_BLOCK_INPUT" = 27 }
+vftable = "MOUSE_DEVICE_VFTABLE"
 ```
 
-The `class` field is the (unmangled) RTTI name of the class whose table to check, and `captures` is a map from capture names to the 0-based index of the virtual method being captured. Note that the resulting RVA points to the function itself, *not* its entry in the VMT.
+The `class` field is the (unmangled) RTTI name of the class whose table to check, and `captures` is a map from capture names to the 0-based index of the virtual method being captured. Note that the resulting RVA points to the function itself, *not* its entry in the VMT. The optional `vftable` field is the capture name for the virtual method table itself.

--- a/tools/binary-mapper/src/main.rs
+++ b/tools/binary-mapper/src/main.rs
@@ -206,7 +206,12 @@ fn generate_rust_struct(profile: &MapperProfile) -> String {
         .iter()
         .flat_map(|entry| &entry.captures)
         .filter(|name| !name.is_empty())
-        .chain(profile.vmts.iter().flat_map(|entry| entry.captures.keys()))
+        .chain(
+            profile
+                .vmts
+                .iter()
+                .flat_map(|entry| entry.captures.keys().chain(entry.vftable.iter())),
+        )
         .collect::<Vec<_>>();
     fields.sort();
     for field in fields {
@@ -303,7 +308,11 @@ struct MapperProfileVmt {
 
     /// A map from names for the captures to indexes in the VMT whose values are
     /// be used as VMTs.
+    #[serde(default)]
     captures: HashMap<String, u32>,
+
+    // A name for the capture of the virtual method table itself.
+    vftable: Option<String>,
 }
 
 impl MapperProfileVmt {
@@ -332,6 +341,10 @@ impl MapperProfileVmt {
 
                 MapperEntryResult::not_found(name)
             })
+            .chain(self.vftable.iter().map(|name| MapperEntryResult {
+                name: name.clone(),
+                rva: class.vftable,
+            }))
             .collect::<Vec<_>>()
     }
 }


### PR DESCRIPTION
Add support to the new vftable mapping for getting the vftable itself. The main use case for this is constructing objects from Rust to pass to the game without re-implementing complex virtual methods

Current hacky approach is to call the constructor on uninitialized memory, C++ style:

```rust
let ctor: CSEzStateTalkEventCtor = unsafe {
    transmute(
        Program::current()
            .rva_to_va(rva::get().cs_ez_state_talk_event_ctor)
            .unwrap(),
    )
};

let mut tmp: MaybeUninit<CSEzStateTalkEvent> = MaybeUninit::uninit();

ctor(tmp.as_mut_ptr(), npc_talk_ins, talk_id);

let ez_state_talk_event = unsafe { tmp.assume_init() };
```

Cooler way would be to explicitly initialize fields in Rust, so we don't have to AOB the constructor and so we have visibility from the mod source code into how the other members are initialized:

```rust
// or usize, if we don't need to access virtual methods from Rust
let vftable: VPtr<dyn CSEzStateTalkEventVmt, Self> = unsafe {
    transmute(
        Program::current()
            .rva_to_va(rva::get().cs_ez_state_talk_event_vmt)
            .unwrap(),
    )
};

let ez_state_talk_event = CSEzStateTalkEvent{
    vftable,
    unk8: 0,
    npc_talk_ins: NonNull::from(npc_talk_ins),
    talk_id,
}
```