### PR TITLE
Move rtti scanner to binary-mapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,12 +95,12 @@ name = "binary-mapper"
 version = "0.11.0"
 dependencies = [
  "clap",
- "fromsoftware-shared",
  "memmap",
  "pelite",
  "rayon",
  "serde",
  "toml",
+ "undname",
 ]
 
 [[package]]
@@ -358,7 +358,6 @@ dependencies = [
  "steamworks-sys",
  "thiserror",
  "tracing",
- "undname",
  "vtable-rs",
  "windows",
 ]
@@ -399,7 +398,6 @@ dependencies = [
  "nalgebra-glm",
  "pelite",
  "thiserror",
- "undname",
  "vtable-rs",
  "windows",
 ]

--- a/crates/eldenring/Cargo.toml
+++ b/crates/eldenring/Cargo.toml
@@ -24,7 +24,6 @@ encoding_rs.workspace = true
 cxx-stl = "3.4"
 steamworks = "0.10"
 steamworks-sys = "0.10"
-undname = "2"
 
 [build-dependencies]
 serde_derive = "1"

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -15,5 +15,4 @@ pelite.workspace = true
 fromsoftware-shared-macros.workspace = true
 thiserror.workspace = true
 vtable-rs.workspace = true
-undname = "2"
 from-singleton = { version = "2" }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -3,7 +3,6 @@ pub mod dl_math;
 pub mod ext;
 pub mod owned_pointer;
 pub mod program;
-pub mod rtti;
 mod r#static;
 pub mod task;
 
@@ -12,7 +11,6 @@ pub use dl_math::*;
 pub use owned_pointer::*;
 pub use program::*;
 pub use r#static::*;
-pub use rtti::*;
 pub use task::*;
 
 pub use from_singleton::FromSingleton;

--- a/tools/binary-mapper/Cargo.toml
+++ b/tools/binary-mapper/Cargo.toml
@@ -8,11 +8,11 @@ license.workspace = true
 
 [dependencies]
 pelite.workspace = true
-fromsoftware-shared.workspace = true
 clap = { version = "4.5.4", features = ["derive", "env"] }
 toml = "0.8"
 memmap = "0.7"
 rayon = "1"
+undname = "2"
 
 [dependencies.serde]
 version = "1"

--- a/tools/binary-mapper/src/main.rs
+++ b/tools/binary-mapper/src/main.rs
@@ -1,16 +1,18 @@
+mod rtti;
+
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::{collections::HashMap, fs, fs::File};
 
 use clap::{command, Args, Parser, ValueEnum};
-use fromsoftware_shared::{find_rtti_classes, Class};
 use memmap::MmapOptions;
 use pelite::{
     pattern,
     pe64::{Pe, PeFile},
 };
 use rayon::prelude::*;
+use rtti::{find_rtti_classes, Class};
 use serde::Deserialize;
 
 #[derive(ValueEnum, Clone)]

--- a/tools/binary-mapper/src/rtti.rs
+++ b/tools/binary-mapper/src/rtti.rs
@@ -1,9 +1,5 @@
-use std::ptr::NonNull;
-
 use pelite::pe64::{msvc::RTTICompleteObjectLocator, Pe, Rva, Va};
 use undname::Flags;
-
-use crate::program::Program;
 
 // TODO: this cast to u32 is probably not going to cause panics but can be prettier.
 const VA_SIZE: u32 = size_of::<Va>() as u32;
@@ -74,45 +70,6 @@ pub fn find_rtti_classes<'a, T: Pe<'a>>(program: &'a T) -> impl Iterator<Item = 
         })
 }
 
-// TODO: use better than usizes.
-/// Attempts to extract the class name for a given vftable.
-pub fn vftable_classname(program: &Program, vftable_va: usize) -> Option<String> {
-    let vftable_rva = program.va_to_rva(vftable_va as u64).ok()?;
-    let vftable_meta_rva = vftable_rva - VA_SIZE;
-
-    let rdata = program
-        .section_headers()
-        .by_name(".rdata")
-        .expect("no .rdata section found");
-
-    let vftable_meta_rva = program
-        .derva(vftable_meta_rva)
-        .and_then(|va| program.va_to_rva(*va))
-        .ok()?;
-
-    if !rdata.virtual_range().contains(&vftable_meta_rva) {
-        return None;
-    }
-
-    let col: &RTTICompleteObjectLocator = program.derva(vftable_meta_rva).ok()?;
-    let ty_name = program
-        .derva_c_str(col.type_descriptor + 16)
-        .ok()?
-        .to_string();
-    if !ty_name
-        .chars()
-        .all(|ch| (0x20..=0x7e).contains(&(ch as u8)))
-    {
-        return None;
-    }
-
-    let demangled = undname::demangle(ty_name.as_str(), Flags::NAME_ONLY)
-        .map(|s| s.to_string())
-        .ok()?;
-
-    Some(demangled)
-}
-
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 #[allow(dead_code)]
 struct RttiCandidate {
@@ -133,18 +90,5 @@ impl<'a, T: Pe<'a>> Class<'a, T> {
     /// Does not validate whether or not the index is actually contained within the VMT.
     pub unsafe fn vmt_fn(&self, index: u32) -> Option<Va> {
         Some(*self.program.derva(self.vftable + VA_SIZE * index).ok()?)
-    }
-
-    /// Retrieves a mutable function pointer from the VMT.
-    ///
-    /// # Safety
-    /// Does not validate whether or not the index is actually contained within the VMT.
-    pub unsafe fn vmt_index(&self, index: u32) -> Option<NonNull<Va>> {
-        let ptr = self
-            .program
-            .rva_to_va(self.vftable + VA_SIZE * index)
-            .ok()? as *const u64 as *mut u64;
-
-        NonNull::new(ptr)
     }
 }


### PR DESCRIPTION
I don't think it's something we actually need in fsrs-shared, since the binary mapper can already do this. So it would be better for it to be part of the binary mapper instead.