### PR TITLE
Bump `from-singleton` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,13 +386,15 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "from-singleton"
-version = "2.0.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39817769d3f0ec454107f15c8d65e34b77e183b401c9f76bd46329528c7b82bc"
+checksum = "2d5292d2f2d406b551902fefa2d7879899306ca37e2866f6bfe596173a3ea17c"
 dependencies = [
+ "fxhash",
+ "memchr",
  "pelite",
- "regex",
- "windows",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -410,6 +418,15 @@ version = "0.11.0"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -16,7 +16,7 @@ fromsoftware-shared-macros.workspace = true
 thiserror.workspace = true
 vtable-rs.workspace = true
 undname = "2"
-from-singleton = { version = "2" }
+from-singleton = "3"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
Updates `from-singleton` to remove the heavy regex dependency (0.6-1.0 MB in release binaries) and makes it faster by 2-3 times.