### PR TITLE
[ER] Update several CSFeMan fields

### DIFF
--- a/crates/eldenring/src/cs/fe_man.rs
+++ b/crates/eldenring/src/cs/fe_man.rs
@@ -98,7 +98,10 @@ pub struct CSFeManImp {
     pub get_item_log_view_model: [u8; 0x1d48],
     unk82a8: [u8; 8],
     pub clock_view_model: usize,
-    unk82b0: [u8; 16],
+    unk82b0: [u8; 8],
+    /// Don't update intermediate `frontend_values` data each frame in the `CSMenuMan` update task
+    pub disable_updates: bool,
+    unk82c1: [u8; 7],
     /// Tag of the debug player
     pub debug_tag: TagHudData,
     unk83f0: [u8; 48],


### PR DESCRIPTION
1 - Add `disable_updates`, which is helpful for manually controlling the timing of FE updates so changes can be made without detours.

2 - `TagHudData.screen_pos_x` and `TagHudData.screen_pos_y` are ints. Evident from `1408c24ab`, where these fields are converted to floats with `cvtdq2ps` before being passed to `FloatClamp` (or from peeking at these values in CE)

```asm
1408c24ab movd      xmm0, DWORD PTR [rbx+0x10] ; data.screen_pos_x
1408c24b0 movzx     eax, cx
1408c24b3 cvtdq2ps  xmm0, xmm0
1408c24b6 movd      xmm2, eax
1408c24ba movzx     eax, dx
1408c24bd cvtdq2ps  xmm2, xmm2
1408c24c0 movd      xmm1, eax
1408c24c4 cvtdq2ps  xmm1, xmm1
1408c24c7 call      FloatClamp
1408c24cc movzx     eax, r14w
1408c24d0 movss     DWORD PTR [rsp+0x30], xmm0
1408c24d6 movd      xmm0, DWORD PTR [rbx+0x14] ; data.screen_pos_y
1408c24db cvtdq2ps  xmm0, xmm0
1408c24de movd      xmm2, eax
1408c24e2 movzx     eax, si
1408c24e5 cvtdq2ps  xmm2, xmm2
1408c24e8 movd      xmm1, eax
1408c24ec cvtdq2ps  xmm1, xmm1
1408c24ef call      FloatClamp
1408c24f4 movss     DWORD PTR [rsp+0x34], xmm0
```