### PR TITLE
Enable the extra-traits feature on the syn package

### DIFF
--- a/crates/shared/macros/Cargo.toml
+++ b/crates/shared/macros/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 inflections = "1.1.1"
 proc-macro2 = "1.0.103"
 quote = "1"
-syn = { version= "2", features = ["full"] }
+syn = { version= "2", features = ["full", "extra-traits"] }


### PR DESCRIPTION
This is necessary because we use `PartialEq` on various types.