### PR TITLE
[ER] Fix layout of ESD event ID and args

### DIFF
--- a/crates/eldenring/src/ez_state/event.rs
+++ b/crates/eldenring/src/ez_state/event.rs
@@ -10,28 +10,28 @@ use crate::{
 
 #[repr(C)]
 /// Holds the arguments for an invocation of an ESD event (i.e. a function call with a side effect).
-/// This contains between 1 and 61 values, since the ID is at index 0 and there is a maximum
-/// capacity of 60 arguments.
+/// This contains an ID and between 0 and 60 argument values.
 ///
 /// Source of name: RTTI
 pub struct EzStateEvent {
     vftable: usize,
-    pub args: DLFixedVector<EzStateRawValue, 61>,
+    pub id: EzStateRawValue,
+    pub args: DLFixedVector<EzStateRawValue, 60>,
     unk3d8: usize,
     unk3f0: usize,
 }
 
 impl EzStateEvent {
     pub fn id(&self) -> i32 {
-        let value: EzStateValue = self.args[0].into();
+        let value: EzStateValue = self.id.into();
         value.into()
     }
 
     pub fn arg(&self, index: u32) -> Option<EzStateValue> {
-        if index as usize >= self.args.len() {
+        if index as usize > self.args.len() {
             None
         } else {
-            Some(self.args[(index + 1) as usize].into())
+            Some(self.args[index as usize].into())
         }
     }
 }
@@ -42,6 +42,7 @@ impl Default for EzStateEvent {
             vftable: Program::current()
                 .rva_to_va(rva::get().ez_state_detail_external_event_temp_vmt)
                 .unwrap() as usize,
+            id: Default::default(),
             args: Default::default(),
             unk3d8: 0,
             unk3f0: 0,
@@ -52,17 +53,28 @@ impl Default for EzStateEvent {
 impl Debug for EzStateEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("EzStateEvent(")?;
+        self.id.fmt(f)?;
+        f.write_str(", ")?;
         self.args.as_slice().fmt(f)?;
         f.write_str(")")
     }
 }
 
-impl<I> From<I> for EzStateEvent
+impl From<i32> for EzStateEvent {
+    fn from(id: i32) -> Self {
+        Self {
+            id: EzStateValue::Int32(id).into(),
+            ..Self::default()
+        }
+    }
+}
+
+impl<I> From<(i32, I)> for EzStateEvent
 where
     I: IntoIterator<Item = EzStateValue>,
 {
-    fn from(args: I) -> Self {
-        let mut new = Self::default();
+    fn from((id, args): (i32, I)) -> Self {
+        let mut new = Self::from(id);
         for arg in args {
             let _ = new.args.push(arg.into());
             if new.args.len() == new.args.capacity() {

--- a/examples/invoke-esd/src/lib.rs
+++ b/examples/invoke-esd/src/lib.rs
@@ -54,55 +54,60 @@ impl TalkScriptDemo {
             }
             TalkScriptDemoState::EnterMainMenu => {
                 // ClearTalkListData()
-                talk_script.event([EzStateValue::Int32(CLEAR_TALK_LIST_DATA)])?;
+                talk_script.event(CLEAR_TALK_LIST_DATA)?;
 
                 // AddTalkListData(1, 20000010, -1) // "Purchase"
-                talk_script.event([
-                    EzStateValue::Int32(ADD_TALK_LIST_DATA),
-                    EzStateValue::Int32(1),
-                    EzStateValue::Int32(20000010),
-                    EzStateValue::Int32(-1),
-                ])?;
+                talk_script.event((
+                    ADD_TALK_LIST_DATA,
+                    [
+                        EzStateValue::Int32(1),
+                        EzStateValue::Int32(20000010),
+                        EzStateValue::Int32(-1),
+                    ],
+                ))?;
 
                 // AddTalkListData(2, 20000011, -1) // "Sell"
-                talk_script.event([
-                    EzStateValue::Int32(ADD_TALK_LIST_DATA),
-                    EzStateValue::Int32(2),
-                    EzStateValue::Int32(20000011),
-                    EzStateValue::Int32(-1),
-                ])?;
+                talk_script.event((
+                    ADD_TALK_LIST_DATA,
+                    [
+                        EzStateValue::Int32(2),
+                        EzStateValue::Int32(20000011),
+                        EzStateValue::Int32(-1),
+                    ],
+                ))?;
 
                 // AddTalkListData(3, 20000009, -1) // "Leave"
-                talk_script.event([
-                    EzStateValue::Int32(ADD_TALK_LIST_DATA),
-                    EzStateValue::Int32(3),
-                    EzStateValue::Int32(20000009),
-                    EzStateValue::Int32(-1),
-                ])?;
+                talk_script.event((
+                    ADD_TALK_LIST_DATA,
+                    [
+                        EzStateValue::Int32(3),
+                        EzStateValue::Int32(20000009),
+                        EzStateValue::Int32(-1),
+                    ],
+                ))?;
 
                 // ShowShopMessage(1)
-                talk_script.event([
-                    EzStateValue::Int32(SHOW_SHOP_MESSAGE),
-                    EzStateValue::Int32(1),
-                ])?;
+                talk_script.event((SHOW_SHOP_MESSAGE, [EzStateValue::Int32(1)]))?;
 
                 TalkScriptDemoState::WhileMainMenu
             }
             TalkScriptDemoState::WhileMainMenu => {
                 // not (CheckSpecificPersonMenuIsOpen(1, 0) == 1 and not CheckSpecificPersonGenericDialogIsOpen(0))
                 let specific_person_menu_is_open: i32 = talk_script
-                    .env([
-                        EzStateValue::Int32(CHECK_SPECIFIC_PERSON_MENU_IS_OPEN),
-                        EzStateValue::Int32(MenuType::TalkList as i32),
-                        EzStateValue::Int32(0),
-                    ])?
+                    .env((
+                        CHECK_SPECIFIC_PERSON_MENU_IS_OPEN,
+                        [
+                            EzStateValue::Int32(MenuType::TalkList as i32),
+                            EzStateValue::Int32(0),
+                        ],
+                    ))?
                     .into();
 
                 let specific_person_generic_dialog_is_open: i32 = talk_script
-                    .env([
-                        EzStateValue::Int32(CHECK_SPECIFIC_PERSON_GENERIC_DIALOG_IS_OPEN),
-                        EzStateValue::Int32(0),
-                    ])?
+                    .env((
+                        CHECK_SPECIFIC_PERSON_GENERIC_DIALOG_IS_OPEN,
+                        [EzStateValue::Int32(0)],
+                    ))?
                     .into();
 
                 if !(specific_person_menu_is_open == 1
@@ -110,26 +115,24 @@ impl TalkScriptDemo {
                 {
                     // GetTalkListMenuResult()
                     match talk_script
-                        .env([EzStateValue::Int32(GET_TALK_LIST_MENU_RESULT)])
+                        .env(GET_TALK_LIST_MENU_RESULT)
                         .map(|v| v.into())?
                     {
                         1 => {
                             // OpenRegularShop(100500, 100524)
-                            talk_script.event([
-                                EzStateValue::Int32(OPEN_REGULAR_SHOP),
-                                EzStateValue::Int32(100500),
-                                EzStateValue::Int32(100524),
-                            ])?;
+                            talk_script.event((
+                                OPEN_REGULAR_SHOP,
+                                [EzStateValue::Int32(100500), EzStateValue::Int32(100524)],
+                            ))?;
 
                             TalkScriptDemoState::WhilePurchase
                         }
                         2 => {
                             // OpenSellShop(-1, -1)
-                            talk_script.event([
-                                EzStateValue::Int32(OPEN_SELL_SHOP),
-                                EzStateValue::Int32(-1),
-                                EzStateValue::Int32(-1),
-                            ])?;
+                            talk_script.event((
+                                OPEN_SELL_SHOP,
+                                [EzStateValue::Int32(-1), EzStateValue::Int32(-1)],
+                            ))?;
 
                             TalkScriptDemoState::WhileSell
                         }
@@ -142,18 +145,20 @@ impl TalkScriptDemo {
             TalkScriptDemoState::WhilePurchase => {
                 // not (CheckSpecificPersonMenuIsOpen(5, 0) == 1 and not CheckSpecificPersonGenericDialogIsOpen(0))
                 let specific_person_menu_is_open: i32 = talk_script
-                    .env([
-                        EzStateValue::Int32(CHECK_SPECIFIC_PERSON_MENU_IS_OPEN),
-                        EzStateValue::Int32(MenuType::RegularShop as i32),
-                        EzStateValue::Int32(0),
-                    ])?
+                    .env((
+                        CHECK_SPECIFIC_PERSON_MENU_IS_OPEN,
+                        [
+                            EzStateValue::Int32(MenuType::RegularShop as i32),
+                            EzStateValue::Int32(0),
+                        ],
+                    ))?
                     .into();
 
                 let specific_person_generic_dialog_is_open: i32 = talk_script
-                    .env([
-                        EzStateValue::Int32(CHECK_SPECIFIC_PERSON_GENERIC_DIALOG_IS_OPEN),
-                        EzStateValue::Int32(0),
-                    ])?
+                    .env((
+                        CHECK_SPECIFIC_PERSON_GENERIC_DIALOG_IS_OPEN,
+                        [EzStateValue::Int32(0)],
+                    ))?
                     .into();
 
                 if !(specific_person_menu_is_open == 1
@@ -167,18 +172,20 @@ impl TalkScriptDemo {
             TalkScriptDemoState::WhileSell => {
                 // not (CheckSpecificPersonMenuIsOpen(5, 0) == 1 and not CheckSpecificPersonGenericDialogIsOpen(0))
                 let specific_person_menu_is_open: i32 = talk_script
-                    .env([
-                        EzStateValue::Int32(CHECK_SPECIFIC_PERSON_MENU_IS_OPEN),
-                        EzStateValue::Int32(MenuType::SellShop as i32),
-                        EzStateValue::Int32(0),
-                    ])?
+                    .env((
+                        CHECK_SPECIFIC_PERSON_MENU_IS_OPEN,
+                        [
+                            EzStateValue::Int32(MenuType::SellShop as i32),
+                            EzStateValue::Int32(0),
+                        ],
+                    ))?
                     .into();
 
                 let specific_person_generic_dialog_is_open: i32 = talk_script
-                    .env([
-                        EzStateValue::Int32(CHECK_SPECIFIC_PERSON_GENERIC_DIALOG_IS_OPEN),
-                        EzStateValue::Int32(0),
-                    ])?
+                    .env((
+                        CHECK_SPECIFIC_PERSON_GENERIC_DIALOG_IS_OPEN,
+                        [EzStateValue::Int32(0)],
+                    ))?
                     .into();
 
                 if !(specific_person_menu_is_open == 1


### PR DESCRIPTION
The current implementation considers event ID to be the first arg, but it's actually a separate field immediately before the arg vector. In other words, the  memory layout is the same but the `len` of the vector is off by one.

This isn't consequential for invoking ESD events from Rust (CSEzStateTalkEvent ignores the extra uninitialized element), but it truncates the args when inspecting vanilla events

Note that `CS::CSEzStateTalkEvent::Invoke` seems to expect events to have one extra arg and be 1-indexed, but this is because the accessors provided by `EzStateExternalEventTemp` pretend the ID is the 0th element of the args for some reason

```c++
int EzState::detail::EzStateExternalEventTemp::GetArgCount(EzStateExternalEventTemp *this)
{
  return (int)(this->args).size + 1;
}

EzStateFuncArg *
EzState::detail::EzStateExternalEventTemp::GetFuncArgData(EzStateExternalEventTemp *this,int index)
{
  if (index == 0) {
    return &this->id;
  }
  return (EzStateFuncArg *)
         ((longlong)&(this->args).elements[index - 1].value + (ulonglong)(-(int)&this->args & 7));
}
```

Also note that the same doesn't apply to env calls, which use a different `EzStateEnvironmentQuery` structure for storing args, but I updated the interface to match for consistency

frida demonstration that ID is not included in the arg count for events:

```ts
import symbols from "./lib/symbols.js";

const eventNames = new Map<number, string>([
    [19, "AddTalkListData"],
    [20, "ClearTalkListData"],
    [22, "OpenRegularShop"],
]);

const envNames = new Map<number, string>([[23, "GetTalkListEntryResult"]]);

Interceptor.attach(symbols["CS::CSEzStateTalkEvent::Invoke"], {
    onEnter(args) {
        const eventId = args[1].add(0x8).readInt();
        const eventArgCount = args[1].add(0x3e0).readULong();

        if (eventNames.has(eventId)) {
            console.log("Event", eventNames.get(eventId), "called with", eventArgCount, "args");
        }
    },
});

Interceptor.attach(symbols["CS::CSEzStateTalkEnv::Invoke"], {
    onEnter(args) {
        const envId = args[2].add(0x10).readInt();
        const envArgCount = args[2].add(0x8).readULong();

        if (envNames.has(envId)) {
            console.log("Env", envNames.get(envId), "called with", envArgCount, "args");
        }
    },
});

```

<img width="375" height="119" alt="image" src="https://github.com/user-attachments/assets/a4950acc-8d19-42ac-9db3-8bd0a54a1d8b" />

The ESD demo doesn't work right now (see #194), but can be verified to still work by making `SuperClass::is_subclass` return true