### PR TITLE
[ER] Avoid using `&mut` for VMT getters

### DIFF
--- a/crates/eldenring/src/cs/file.rs
+++ b/crates/eldenring/src/cs/file.rs
@@ -14,7 +14,7 @@ pub trait CSFileImpVmt {
     fn destructor(&mut self, param_2: u32);
 
     /// Retrieves a file cap from the primary file repository.
-    fn get_file_cap(&mut self, name: &FD4BasicHashString) -> Option<NonNull<FD4FileCap>>;
+    fn get_file_cap(&self, name: &FD4BasicHashString) -> Option<NonNull<FD4FileCap>>;
 
     /// Adds a file cap to the primary file repository. The file loading queue parameters indicates
     /// what file loading queue the load events will be handled by.


### PR DESCRIPTION
Because there's no way to make these polymorphic over mutability, we should define them in terms of pointers and immutable self and then add explicitly mutable wrappers where necessary.