### PR TITLE
[Shared] Implement dynamic cast for Superclass::as_subclass using RTTI data

### DIFF
--- a/crates/shared/src/subclass.rs
+++ b/crates/shared/src/subclass.rs
@@ -69,7 +69,7 @@ pub unsafe trait Superclass: Sized {
         // Otherwise, dynamically check using RTTI data
         let instance_col = unsafe { complete_object_locator(instance_vmt) };
         let subclass_col = unsafe { complete_object_locator(subclass_vmt) };
-        is_base_class(&Program::current(), subclass_col, instance_col)
+        is_base_class(&Program::current(), subclass_col, instance_col).unwrap_or(false)
     }
 
     /// Returns this as a `T` if it is one. Otherwise, returns `None`.
@@ -102,7 +102,6 @@ pub unsafe trait Superclass: Sized {
 /// In order to implement this for a struct, you must guarantee:
 ///
 /// * The struct uses C-style layout.
-/// * The first element of the struct is a pointer to a vtable for a class with MSVC RTTI.
 /// * An initial subsequence of the struct is a valid instance of `T`.
 pub unsafe trait Subclass<T: Superclass> {
     /// The RVA of this class's virtual method table.


### PR DESCRIPTION
Check the base class array using RTTI when dynamic casting an object using the superclass trait

Testing:

```rust
let program = &Program::current();

let cols: Vec<(&str, &RTTICompleteObjectLocator)> = vec![
    ("FieldInsBase", program.derva(0x32ca188).unwrap()),
    ("ChrIns", program.derva(0x32cd0e0).unwrap()),
    ("PlayerIns", program.derva(0x32e4b30).unwrap()),
    ("CSBulletIns", program.derva(0x32ca0b8).unwrap()),
    ("WorldChrManImp", program.derva(0x32d67c8).unwrap()),
];

for (subclass_name, subclass_col) in cols.iter() {
    for (baseclass_name, baseclass_col) in cols.iter() {
        if subclass_name != baseclass_name
            && is_base_class(program, baseclass_col, subclass_col)
        {
            println!("{} is a {}", subclass_name, baseclass_name);
        }
    }
}
```

<img width="242" height="57" alt="image" src="https://github.com/user-attachments/assets/a8ab1563-6613-4862-8990-f93ed50241a4" />

Fixes #194