### PR TITLE
[ER] Make `PlayerIns::player_game_data` a `NonNull`

### DIFF
--- a/crates/eldenring/src/cs/chr_ins.rs
+++ b/crates/eldenring/src/cs/chr_ins.rs
@@ -822,7 +822,7 @@ pub struct CSChrModelIns {
 /// Source of name: RTTI
 pub struct PlayerIns {
     pub chr_ins: ChrIns,
-    pub player_game_data: OwnedPtr<PlayerGameData>,
+    pub player_game_data: NonNull<PlayerGameData>,
     chr_manipulator: usize,
     unk590: usize,
     pub player_session_holder: PlayerSessionHolder,

--- a/tools/debug-eldenring/src/display/chr.rs
+++ b/tools/debug-eldenring/src/display/chr.rs
@@ -26,7 +26,7 @@ impl StatefulDebugDisplay for PlayerIns {
         chr_ins_common_debug(&mut self.chr_ins, ui, state);
 
         ui.nested("ChrAsm", &self.chr_asm);
-        ui.nested("PlayerGameData", &self.player_game_data);
+        ui.nested("PlayerGameData", unsafe { self.player_game_data.as_ref() });
         ui.nested(
             "Session Player Entry",
             self.session_manager_player_entry.as_ref(),


### PR DESCRIPTION
This is already owned by PlayerGameData.