### PR TITLE
[ER] Refactor resource and param code a bit

### DIFF
--- a/crates/darksouls3/src/sprj/regulation_manager.rs
+++ b/crates/darksouls3/src/sprj/regulation_manager.rs
@@ -215,8 +215,8 @@ impl CSRegulationManager {
             .unwrap_or_else(|| panic!("Expected param index {} to be {}", index, T::NAME))
     }
 
-    /// Returns a dynamically-dispatched equipment parameter row for the given
-    /// item ID, or `None` if the row doesn't exit.
+    /// Returns an equipment parameter row enum for the given item ID, or `None`
+    /// if the row doesn't exit.
     pub fn get_equip_param(&self, id: ItemId) -> Option<EquipParamStruct<'_>> {
         use ItemCategory::*;
         match id.category() {
@@ -241,8 +241,8 @@ impl CSRegulationManager {
         }
     }
 
-    /// Returns a dynamically-dispatched mutable equipment parameter row for the
-    /// given item ID, or `None` if the row doesn't exit.
+    /// Returns a mutable equipment parameter row enum for the given item ID, or `None`
+    /// if the row doesn't exit.
     pub fn get_equip_param_mut(&mut self, id: ItemId) -> Option<EquipParamStructMut<'_>> {
         use ItemCategory::*;
         match id.category() {

--- a/crates/eldenring/mapper-profile.toml
+++ b/crates/eldenring/mapper-profile.toml
@@ -210,6 +210,10 @@ vftable = "ichr_finder_vmt"
 class = "CS::NearEnemyFinder"
 vftable = "near_enemy_finder_vmt"
 
+[[vmts]]
+class = "CS::SoloParamRepositoryImp"
+vftable = "solo_param_repository_vmt"
+
 [[patterns]]
 pattern = "48 8d 05 $ { ' } 48 89 4f 68 88 4f 70 48 89 4f 78 48 89 07 48 8b 43 18"
 captures = ["", "fd4file_cap_vmt"]

--- a/crates/eldenring/src/cs/solo_param_repository.rs
+++ b/crates/eldenring/src/cs/solo_param_repository.rs
@@ -1,13 +1,8 @@
 use shared::{OwnedPtr, Subclass};
 
-use crate::{
-    ArrayWithHeader, Vector,
-    cs::BlockId,
-    dlkr::DLAllocatorRef,
-    fd4::{FD4ParamResCap, FD4ResCap, FD4ResRep, ParamFile},
-    param::ParamDef,
-    stl::Tree,
-};
+use super::{BlockId, ItemCategory, ItemId};
+use crate::fd4::{FD4ParamResCap, FD4ResCap, FD4ResRep, ParamFile};
+use crate::{ArrayWithHeader, Vector, dlkr::DLAllocatorRef, param::ParamDef, stl::Tree};
 use bitfield::bitfield;
 
 #[repr(C)]
@@ -174,9 +169,9 @@ impl ParamResCap {
 
         let struct_name = self.param_res_cap.data.struct_name();
         debug_assert!(
-            struct_name == P::UnderlyingType::NAME,
+            struct_name == P::StructType::NAME,
             "Expected param struct {}, was {}",
-            P::UnderlyingType::NAME,
+            P::StructType::NAME,
             struct_name,
         );
     }
@@ -202,16 +197,23 @@ pub struct SoloParamHolder {
 }
 
 impl SoloParamHolder {
+    /// The res cap at `index` in this holder, if it exists.
     pub fn get_res_cap(&self, index: usize) -> Option<&ParamResCap> {
         self.res_caps.get(index)?.as_deref()
     }
+
+    /// The mutable res cap at `index` in this holder, if it exists.
     pub fn get_res_cap_mut(&mut self, index: usize) -> Option<&mut ParamResCap> {
         self.res_caps.get_mut(index)?.as_deref_mut()
     }
-    pub fn get_res_caps(&self) -> impl Iterator<Item = &ParamResCap> {
+
+    /// An iterator over all res caps in this holder.
+    pub fn res_caps(&self) -> impl Iterator<Item = &ParamResCap> {
         self.res_caps.iter().filter_map(|opt| opt.as_deref())
     }
-    pub fn get_res_caps_mut(&mut self) -> impl Iterator<Item = &mut ParamResCap> {
+
+    /// An iterator over all mutable res caps in this holder.
+    pub fn res_caps_mut(&mut self) -> impl Iterator<Item = &mut ParamResCap> {
         self.res_caps
             .iter_mut()
             .filter_map(|opt| opt.as_deref_mut())
@@ -220,6 +222,7 @@ impl SoloParamHolder {
 
 #[repr(C)]
 #[shared::singleton("SoloParamRepository")]
+#[derive(Subclass)]
 pub struct SoloParamRepository {
     pub res_rep: FD4ResRep,
     unk78: u32,
@@ -249,6 +252,22 @@ pub struct SoloParamRepository {
 }
 
 impl SoloParamRepository {
+    /// An iterator over all solo parameters.
+    pub fn params(&self) -> impl Iterator<Item = &FD4ParamResCap> {
+        self.solo_param_holders
+            .iter()
+            .flat_map(|h| h.res_caps())
+            .map(|rc| rc.param_res_cap.as_ref())
+    }
+
+    /// An iterator over all mutable solo parameters.
+    pub fn params_mut(&mut self) -> impl Iterator<Item = &mut FD4ParamResCap> {
+        self.solo_param_holders
+            .iter_mut()
+            .flat_map(|h| h.res_caps_mut())
+            .map(|rc| rc.param_res_cap.as_mut())
+    }
+
     pub fn get_chr_equip_model_param_by_key(
         &self,
         equip_type: u8,
@@ -301,21 +320,23 @@ impl SoloParamRepository {
     }
 
     /// Get a solo param (regulation.bin) row by its parameter type and ID.
-    pub fn get<P: SoloParam>(&self, param_id: u32) -> Option<&P::UnderlyingType> {
-        // SAFETY: `get_param_file` checks that the param type is what we expect.
+    pub fn get<P: SoloParam>(&self, param_id: u32) -> Option<&P::StructType> {
+        // SAFETY: By construction, [SoloParam] only applies to parameters whose
+        // indices are guaranteed by the game to be consistent.
         unsafe {
             self.get_param_file::<P>()
-                .get_row_by_id::<P::UnderlyingType>(param_id)
+                .get_row_by_id::<P::StructType>(param_id)
         }
     }
 
     /// Get a mutable solo param (regulation.bin) row by its parameter type and
     /// ID.
-    pub fn get_mut<P: SoloParam>(&mut self, param_id: u32) -> Option<&mut P::UnderlyingType> {
-        // SAFETY: `get_param_file` checks that the param type is what we expect.
+    pub fn get_mut<P: SoloParam>(&mut self, param_id: u32) -> Option<&mut P::StructType> {
+        // SAFETY: By construction, [SoloParam] only applies to parameters whose
+        // indices are guaranteed by the game to be consistent.
         unsafe {
             self.get_param_file_mut::<P>()
-                .get_row_by_id_mut::<P::UnderlyingType>(param_id)
+                .get_row_by_id_mut::<P::StructType>(param_id)
         }
     }
 
@@ -326,11 +347,12 @@ impl SoloParamRepository {
     /// this when you already know the index from a mapping like
     /// [SoloParamRepository::wep_reinforces] or
     /// [SoloParamRepository::buddy_stone_entity_ids].
-    pub fn get_row_by_index<P: SoloParam>(&self, row_index: usize) -> Option<&P::UnderlyingType> {
-        // SAFETY: `get_param_file` checks that the param type is what we expect.
+    pub fn get_row_by_index<P: SoloParam>(&self, row_index: usize) -> Option<&P::StructType> {
+        // SAFETY: By construction, [SoloParam] only applies to parameters whose
+        // indices are guaranteed by the game to be consistent.
         unsafe {
             self.get_param_file::<P>()
-                .get_row_by_index::<P::UnderlyingType>(row_index)
+                .get_row_by_index::<P::StructType>(row_index)
         }
     }
 
@@ -344,18 +366,85 @@ impl SoloParamRepository {
     pub fn get_row_by_index_mut<P: SoloParam>(
         &mut self,
         row_index: usize,
-    ) -> Option<&mut P::UnderlyingType> {
-        // SAFETY: `get_param_file` checks that the param type is what we expect.
+    ) -> Option<&mut P::StructType> {
+        // SAFETY: By construction, [SoloParam] only applies to parameters whose
+        // indices are guaranteed by the game to be consistent.
         unsafe {
             self.get_param_file_mut::<P>()
-                .get_row_by_index_mut::<P::UnderlyingType>(row_index)
+                .get_row_by_index_mut::<P::StructType>(row_index)
         }
     }
 
     /// Returns the index of a solo param (regulation.bin) row by its parameter
     /// type and ID.
     pub fn get_index_by_param_id<P: SoloParam>(&self, param_id: u32) -> Option<usize> {
-        self.get_param_file::<P>().metadata().find_index(param_id)
+        self.get_param_file::<P>().find_index(param_id)
+    }
+
+    /// Returns an equipment parameter row enum for the given item ID, or `None`
+    /// if the row doesn't exit.
+    pub fn get_equip_param(&self, id: ItemId) -> Option<EquipParamStruct<'_>> {
+        use ItemCategory::*;
+        match id.category() {
+            Weapon => self
+                // Round to the nearest 100 in case the ID is for an upgraded
+                // weapon.
+                .get::<EquipParamWeapon>((id.param_id() / 100) * 100)
+                .map(|p| EquipParam::as_enum(p)),
+            Protector => self
+                .get::<EquipParamProtector>(id.param_id())
+                .map(|p| EquipParam::as_enum(p)),
+            Accessory => self
+                .get::<EquipParamAccessory>(id.param_id())
+                .map(|p| EquipParam::as_enum(p)),
+            Gem => self
+                .get::<EquipParamGem>(id.param_id())
+                .map(|p| EquipParam::as_enum(p)),
+            Goods => self
+                .get::<EquipParamGoods>(id.param_id())
+                .map(|p| EquipParam::as_enum(p)),
+        }
+    }
+
+    /// Returns a mutable equipment parameter row enum for the given item ID, or `None`
+    /// if the row doesn't exit.
+    pub fn get_equip_param_mut(&mut self, id: ItemId) -> Option<EquipParamStructMut<'_>> {
+        use ItemCategory::*;
+        match id.category() {
+            Weapon => self
+                // Round to the nearest 100 in case the ID is for an upgraded
+                // weapon.
+                .get_mut::<EquipParamWeapon>((id.param_id() / 100) * 100)
+                .map(|p| EquipParam::as_enum_mut(p)),
+            Protector => self
+                .get_mut::<EquipParamProtector>(id.param_id())
+                .map(|p| EquipParam::as_enum_mut(p)),
+            Accessory => self
+                .get_mut::<EquipParamAccessory>(id.param_id())
+                .map(|p| EquipParam::as_enum_mut(p)),
+            Gem => self
+                .get_mut::<EquipParamGem>(id.param_id())
+                .map(|p| EquipParam::as_enum_mut(p)),
+            Goods => self
+                .get_mut::<EquipParamGoods>(id.param_id())
+                .map(|p| EquipParam::as_enum_mut(p)),
+        }
+    }
+
+    /// Returns an iterator over each row in parameter `P` along with their
+    /// parameter IDs, in ID order.
+    pub fn rows<'a, P: SoloParam + 'a>(
+        &'a self,
+    ) -> impl Iterator<Item = (u32, &'a P::StructType)> + 'a {
+        unsafe { self.get_param_file::<P>().rows() }
+    }
+
+    /// Returns an iterator over each mutable row in parameter `P` along with
+    /// their parameter IDs, in ID order.
+    pub fn rows_mut<'a, P: SoloParam + 'a>(
+        &'a mut self,
+    ) -> impl Iterator<Item = (u32, &'a mut P::StructType)> + 'a {
+        unsafe { self.get_param_file_mut::<P>().rows_mut() }
     }
 
     /// Returns the [ParamFile] associated with `P`, if it exists at the
@@ -405,23 +494,37 @@ impl SoloParamRepository {
     }
 }
 
+/// A shared trait for parameters that are part of [SoloParamRepository], used
+/// to ensure that they can be accessed in a type-safe way.
 pub trait SoloParam {
+    /// The parameter name. This corresponds to `ParamResCap.res_cap.name` and
+    /// `FD4ParamResCap.res_cap.name`, not to [ParamFile::struct_name] and
+    /// [ParamDef::NAME].
     const NAME: &'static str;
+
+    /// The index of this parameter in [SoloParamRepository].
     const INDEX: u32;
-    type UnderlyingType: ParamDef;
+
+    /// The type of the data that this parameter contains.
+    type StructType: ParamDef;
 }
 
 use crate::param::*;
 
 macro_rules! solo_params {
-    ( $( ($ParamType:ident, $UnderlyingType:ty, $Index:expr) ),* $(,)? ) => {
+    ( $( ($ParamType:ident, $StructType:ty, $Index:expr) ),* $(,)? ) => {
         $(
+            #[doc="The"]
+            #[doc=stringify!($ParamType)]
+            #[doc="parameter. This can be used with [SoloParamRepository::get] and similar methods"]
+            #[doc="to load parameter data."]
             #[allow(non_camel_case_types)]
             pub struct $ParamType;
+
             impl SoloParam for $ParamType {
                 const NAME: &'static str = stringify!($ParamType);
                 const INDEX: u32 = $Index;
-                type UnderlyingType = $UnderlyingType;
+                type StructType = $StructType;
             }
         )*
     };

--- a/crates/eldenring/src/fd4/basic_hash_string.rs
+++ b/crates/eldenring/src/fd4/basic_hash_string.rs
@@ -3,17 +3,22 @@ use std::{cmp::PartialEq, fmt::Display};
 use crate::dltx::{DLString, DLStringKind, DLUTF16StringKind};
 
 #[repr(C)]
-/// Wraps a string to make it easier to use with hashmaps. Seemingly mostly used in the resource
-/// system but has some usage elsewhere too.
+/// A string wrapper that caches the associated hash code.
+///
+/// This is frequently used in the resource system, which is built on hash maps.
+/// It's occasioanlly used elsewhere as well.
 ///
 /// Source of name: RTTI
 pub struct FD4BasicHashString<T: DLStringKind = DLUTF16StringKind> {
     vftable: usize,
-    /// The contained string we're hashing for.
+
+    /// The inner string.
     pub inner: DLString<T>,
-    /// Hashed representation of the string field.
+
+    /// The string's hash code, or 0 if it hasn't yet been computed.
     pub hash: u32,
-    /// Indicates whether or not the hash field is populated.
+
+    /// Whether or not [Self::hash] has been computed.
     pub needs_hashing: bool,
     // _pad3d: [u8; 0x3],
 }

--- a/crates/eldenring/src/fd4/param_repository.rs
+++ b/crates/eldenring/src/fd4/param_repository.rs
@@ -1,13 +1,10 @@
-use std::ffi::CStr;
+use std::{ffi::CStr, iter, ptr::NonNull, slice};
 
 use crate::fd4::FD4ResCapHolder;
 use crate::param::ParamDef;
 use shared::{OwnedPtr, Subclass};
 
-use super::FD4ResRep;
-use super::resource::FD4ResCap;
-
-use param_layout::{ParamLayout, ParamLayout32, ParamLayout64};
+use super::{FD4ResCap, FD4ResRep};
 
 // Under most circumstances, it would make the most sense to consider
 // [FD4ParamRepository] to be the owner of the [FD4ParamResCap]s it contains.
@@ -67,8 +64,8 @@ impl FD4ParamRepository {
     ///
     /// This accesses data that `fromsoftware-rs` considers to be owned by
     /// individual parameter repositories such as [`SoloParamRepository`]. The
-    /// caller must guarantee that there are no mutable references to *any*
-    /// parameter data anywhere in the program before calling this.
+    /// caller must guarantee that there are no other references to *any* parameter
+    /// data anywhere in the program before calling this.
     ///
     /// [`SoloParamRepository`]: crate::cs::SoloParamRepository
     pub unsafe fn res_cap_holder_mut(&mut self) -> &mut FD4ResCapHolder<FD4ParamResCap> {
@@ -126,10 +123,12 @@ impl FD4ParamRepository {
 #[repr(C)]
 #[derive(Subclass)]
 pub struct FD4ParamResCap {
-    inner: FD4ResCap,
-    /// Size of data at pointer.
-    size: u64,
-    /// Raw row data for this param file.
+    pub res_cap: FD4ResCap,
+
+    /// The size in bytes of the [ParamFile] pointed at by [Self::data].
+    pub size: u64,
+
+    /// The raw row data for this param resource.
     pub data: OwnedPtr<ParamFile>,
 }
 
@@ -145,6 +144,9 @@ impl FD4ParamResCap {
         self.data.struct_name()
     }
 
+    /// Returns the row in this parameter with the given `id`, interpreted as a
+    /// `P`.
+    ///
     /// # Safety
     ///
     /// Type `P` must match the actual row data structure for this param file.
@@ -152,6 +154,9 @@ impl FD4ParamResCap {
         unsafe { self.data.get_row_by_id(id) }
     }
 
+    /// Returns the mutable row in this parameter with the given `id`,
+    /// interpreted as a `P`.
+    ///
     /// # Safety
     ///
     /// Type `P` must match the actual row data structure for this param file.
@@ -161,80 +166,82 @@ impl FD4ParamResCap {
 }
 
 /// Runtime metadata prepended at offset -0x10 from the param file.
-///
-/// Memory layout:
-/// ```text
-/// [ParamHeaderMetadata]          <- file_ptr-0x10
-/// [ParamFile]                    <- file_ptr (FD4ParamResCap.file points here)
-/// [row data...]
-/// [aligned padding to 0x10]
-/// [RowLookupEntry * row_count]   <- sorted by param ID lookup table
-/// ```
 #[repr(C)]
-pub struct ParamHeaderMetadata {
-    file_size: u32,
+struct ParamFileMetadata {
+    /// The unaligned offset from the beginning of the parameter file to the end
+    /// of its name string (or its [RowDescriptor] array if the name is stored
+    /// inline).
+    after_name_offset: u32,
+
+    /// The number of rows in the parameter file.
     row_count: u32,
+
     _reserved: u64,
 }
 
-impl ParamHeaderMetadata {
-    const ALIGNMENT: u32 = 0x10;
-    const SIZE: usize = size_of::<Self>();
-
-    fn lookup_table(&self) -> &[RowLookupEntry] {
-        let aligned_file_size = self.file_size.next_multiple_of(Self::ALIGNMENT) as usize;
-
-        unsafe {
-            let file_start = (self as *const Self).add(1) as *const u8;
-            std::slice::from_raw_parts(
-                file_start.add(aligned_file_size) as *const RowLookupEntry,
-                self.row_count as usize,
-            )
-        }
-    }
-
-    pub fn find_index(&self, param_id: u32) -> Option<usize> {
-        let table = self.lookup_table();
-        let target_index = self
-            .lookup_table()
-            .binary_search_by(|entry| entry.param_id.cmp(&param_id))
-            .ok()?;
-        Some(table[target_index].index as usize)
-    }
-}
-
-/// Entry in the runtime lookup table for O(log n) access by row ID.
+/// An entry in the runtime lookup table to look up rows by ID.
+///
+/// This table is sorted by ID, enabling O(log n) lookups.
 #[repr(C)]
 struct RowLookupEntry {
     param_id: u32,
     index: u32,
 }
 
-/// Row descriptor for param files.
+/// A row descriptor that makes Row descriptor for param files.
 ///
 /// The actual size depends on the offset type:
 /// - 32-bit offsets: 12 bytes (id + data_offset + name_offset)
 /// - 64-bit offsets: 24 bytes (id + pad + data_offset + name_offset)
 #[repr(C)]
-pub struct RowDescriptor<O: ParamLayout> {
-    pub id: u32,
-    pub data_offset: O::FileOffsetType,
-    pub name_offset: O::FileOffsetType,
+struct RowDescriptor<T: Into<u64> + Copy> {
+    /// The parameter ID of the row this describes.
+    id: u32,
+
+    data_offset: T,
+
+    /// The offset between the beginning of the [ParamFile] and its struct name.
+    /// This is the same for all descriptors.
+    name_offset: T,
 }
 
-impl<O: ParamLayout> RowDescriptor<O> {
+impl<T: Into<u64> + Copy> RowDescriptor<T> {
+    /// The offset between the beginning of the [ParamFile] and the [ParamDef]
+    /// data this descriptor refers to.
     pub fn data_offset(&self) -> usize {
         self.data_offset.into() as usize
     }
 }
 
-/// Param file accessor that handles format variations at runtime.
+/// An in-memory representation of a file that contains all the data for a
+/// single parameter type.
+// Memory layout:
+// ```text
+// [ParamFileMetadata]            <- file_ptr-0x10
+// [ParamFile]                    <- file_ptr ([FD4ParamResCap::file] points here)
+// [RowDescriptor * row_count]
+// [char...]                      <- struct name, if [ParamFile::has_offset_param_type] is true
+// [aligned padding to 0x10]
+// [ParamDef * row_count]         <- file_ptr + RowDescriptor::data_offset
+// [RowLookupEntry * row_count]   <- lookup table for param indexes, sorted by param ID
+// ```
 #[repr(C)]
 pub struct ParamFile {
-    header: ParamHeader,
+    strings_offset: u32,
+    short_data_offset: u16,
+    _unk06: u16,
+    paramdef_version: u16,
+    row_count: u16,
+    struct_name: ParamStructName,
+    big_endian: u8,
+    format_2d: u8,
+    format_2e: u8,
 }
 
 impl ParamFile {
+    /// The alignment used for the beginning of the [RowLookupEntry] table.
+    const LOOKUP_TABLE_ALIGNMENT: u32 = 0x10;
+
     /// Returns the name of the struct that this parameter uses.
     ///
     /// This corresponds to [`ParamDef::NAME`] (typically written in all-caps
@@ -243,70 +250,162 @@ impl ParamFile {
     ///
     /// [`ParamDef::NAME`]: crate::param::ParamDef::NAME
     pub fn struct_name(&self) -> &str {
-        if self.header.has_offset_param_type() {
+        if self.has_offset_param_type() {
             self.read_offset_struct_name()
         } else {
             self.read_inline_struct_name()
         }
     }
 
-    pub const fn row_count(&self) -> usize {
-        self.header.row_count as usize
-    }
-
+    /// The revision of this paramdef struct type.
     pub const fn paramdef_version(&self) -> u16 {
-        self.header.paramdef_data_version
+        self.paramdef_version
     }
 
+    /// The number of rows this file contains.
+    pub const fn row_count(&self) -> usize {
+        self.row_count as usize
+    }
+
+    /// Returns the row in this file with the given `id`, if one exists.
+    ///
     /// # Safety
     ///
     /// Type `P` must match the actual row data structure for this param file.
     pub unsafe fn get_row_by_id<P: ParamDef>(&self, id: u32) -> Option<&P> {
-        let row_index = self.metadata().find_index(id)?;
-        let data_offset = self.row_data_offset(row_index)?;
-        Some(unsafe { &*(self.as_ptr().add(data_offset) as *const P) })
+        let index = self.find_index(id)?;
+        let (actual_id, data_offset) = self.row_data_offset(index)?;
+        debug_assert_eq!(id, actual_id, "Unexpected row ID for {}", P::NAME);
+        Some(unsafe { self.offset::<P>(data_offset).as_ref() })
     }
 
+    /// Returns the mutable row in this file with the given `id`, if one exists.
+    ///
     /// # Safety
     ///
     /// Type `P` must match the actual row data structure for this param file.
     pub unsafe fn get_row_by_id_mut<P: ParamDef>(&mut self, id: u32) -> Option<&mut P> {
-        let row_index = self.metadata().find_index(id)?;
-        let data_offset = self.row_data_offset(row_index)?;
-        Some(unsafe { &mut *(self.as_ptr().add(data_offset) as *mut P) })
+        let index = self.find_index(id)?;
+        let (actual_id, data_offset) = self.row_data_offset(index)?;
+        debug_assert_eq!(id, actual_id, "Unexpected row ID for {}", P::NAME);
+        Some(unsafe { self.offset::<P>(data_offset).as_mut() })
     }
 
+    /// Returns the row in this file at the given `index`, if one exists.
+    ///
     /// # Safety
     ///
     /// Type `P` must match the actual row data structure for this param file.
     pub unsafe fn get_row_by_index<P: ParamDef>(&self, row_index: usize) -> Option<&P> {
-        let data_offset = self.row_data_offset(row_index)?;
-        Some(unsafe { &*(self.as_ptr().add(data_offset) as *const P) })
+        let data_offset = self.row_data_offset(row_index)?.1;
+        Some(unsafe { self.offset::<P>(data_offset).as_ref() })
     }
 
+    /// Returns the mutable row in this file at the given `index`, if one exists.
+    ///
     /// # Safety
     ///
     /// Type `P` must match the actual row data structure for this param file.
     pub unsafe fn get_row_by_index_mut<P: ParamDef>(&mut self, row_index: usize) -> Option<&mut P> {
-        let data_offset = self.row_data_offset(row_index)?;
-        Some(unsafe { &mut *(self.as_ptr().add(data_offset) as *mut P) })
+        let data_offset = self.row_data_offset(row_index)?.1;
+        Some(unsafe { self.offset::<P>(data_offset).as_mut() })
     }
 
-    pub const fn metadata(&self) -> &ParamHeaderMetadata {
+    /// Returns an iterator over each row in this file along with their parameter IDs,
+    /// in ID order.
+    ///
+    /// # Safety
+    ///
+    /// Type `P` must match the actual row data structure for this param file.
+    pub unsafe fn rows<'a, P: ParamDef + 'a>(&'a self) -> impl Iterator<Item = (u32, &'a P)> + 'a {
+        self.lookup_table()
+            .iter()
+            .map(|l| unsafe { (l.index, self.get_row_by_index(l.index as usize).unwrap()) })
+    }
+
+    /// Returns an iterator over each mutable row in this file along with their
+    /// parameter IDs, in ID order.
+    ///
+    /// # Safety
+    ///
+    /// Type `P` must match the actual row data structure for this param file.
+    pub unsafe fn rows_mut<'a, P: ParamDef + 'a>(
+        &'a mut self,
+    ) -> impl Iterator<Item = (u32, &'a mut P)> + 'a {
+        // We have to do this more manually to avoid having a reference to the
+        // `lookup_table` slice coexisting with the mutable reference returned
+        // by the iterator.
+        let mut file = NonNull::from_ref(self);
+        let range = self.lookup_table().as_ptr_range();
+        let mut ptr = range.start;
+        let end = range.end;
+
+        iter::from_fn(move || {
+            if ptr == end {
+                return None;
+            }
+
+            // Safety: We know `ptr` is valid because the iterator holds a
+            // reference to `self` and thus to its lookup table, and `ptr` can't
+            // be `end` at this point. We know `file` is valid because of that
+            // same reference.
+            unsafe {
+                let index = ptr.as_ref().unwrap().index;
+                let result = file.as_mut().get_row_by_index_mut(index as usize).unwrap();
+                ptr = ptr.add(1);
+                Some((index, result))
+            }
+        })
+    }
+
+    /// Returns the index of the parameter row with the given `id`.
+    pub fn find_index(&self, id: u32) -> Option<usize> {
+        let table = self.lookup_table();
+        let target_index = self
+            .lookup_table()
+            .binary_search_by(|entry| entry.param_id.cmp(&id))
+            .ok()?;
+        Some(table[target_index].index as usize)
+    }
+
+    /// Returns a reference to the lookup table used to efficiently map
+    /// parameter IDs to indices.
+    fn lookup_table(&self) -> &[RowLookupEntry] {
+        let aligned_file_size =
+            self.metadata()
+                .after_name_offset
+                .next_multiple_of(Self::LOOKUP_TABLE_ALIGNMENT) as usize;
+
         unsafe {
-            let metadata_ptr = (self as *const Self).byte_sub(ParamHeaderMetadata::SIZE)
-                as *const ParamHeaderMetadata;
+            slice::from_raw_parts(
+                self.offset::<RowLookupEntry>(aligned_file_size).as_ptr(),
+                self.row_count as usize,
+            )
+        }
+    }
+
+    /// Returns the metadata that's stored in memory before this file.
+    const fn metadata(&self) -> &ParamFileMetadata {
+        unsafe {
+            let metadata_ptr = (self as *const Self).byte_sub(size_of::<ParamFileMetadata>())
+                as *const ParamFileMetadata;
             &*metadata_ptr
         }
     }
 
-    fn as_ptr(&self) -> *const u8 {
-        self as *const Self as *const u8
+    /// Returns a pointer to [offset] bytes after the beginning of this struct.
+    ///
+    /// ## Safety
+    ///
+    /// The `offset` must be in range of [isize] and the resulting addition must
+    /// not overflow the address space.
+    const unsafe fn offset<T>(&self, offset: usize) -> NonNull<T> {
+        unsafe { NonNull::from_ref(self).cast::<u8>().add(offset).cast::<T>() }
     }
 
     fn read_inline_struct_name(&self) -> &str {
         unsafe {
-            CStr::from_ptr(self.header.struct_name.inline.as_ptr() as *const i8)
+            CStr::from_ptr(self.struct_name.inline.as_ptr() as *const i8)
                 .to_str()
                 .unwrap_or("")
         }
@@ -314,63 +413,48 @@ impl ParamFile {
 
     fn read_offset_struct_name(&self) -> &str {
         unsafe {
-            let offset = self.header.struct_name.offset.value;
+            let offset = self.struct_name.offset.value;
             if offset == 0 {
                 return "";
             }
-            CStr::from_ptr(self.as_ptr().add(offset as usize) as *const i8)
+            CStr::from_ptr(self.offset::<i8>(offset as usize).as_ptr())
                 .to_str()
                 .unwrap_or("")
         }
     }
 
-    /// Extended header offset is 0x40 bytes, otherwise 0x30
-    const fn row_descriptors_offset(&self) -> usize {
-        const HEADER_SIZE: usize = size_of::<ParamHeader>();
-        if self.header.has_extended_header() {
-            return HEADER_SIZE + 0x10;
-        };
-        HEADER_SIZE
+    /// Returns this param file's row descriptor list. This uses the same
+    /// indices as the paramter data.
+    const fn row_descriptors<T: Into<u64> + Copy>(&self) -> &[RowDescriptor<T>] {
+        let offset = size_of::<ParamFile>() + if self.has_extended_header() { 0x10 } else { 0 };
+        unsafe {
+            slice::from_raw_parts(
+                self.offset::<RowDescriptor<T>>(offset).as_ptr(),
+                self.row_count as usize,
+            )
+        }
     }
 
-    fn row_data_offset(&self, row_index: usize) -> Option<usize> {
+    /// Returns the parameter ID and offset from the beginning of this paramter
+    /// file to the data of the row at `row_index`.
+    ///
+    /// Returns `None` if `row_index` is out-of-range for this file.
+    fn row_data_offset(&self, row_index: usize) -> Option<(u32, usize)> {
         if row_index >= self.row_count() {
             return None;
         }
-        let base = self.row_descriptors_offset();
 
-        unsafe {
-            if self.header.is_64_bit() {
-                let desc = &*(self
-                    .as_ptr()
-                    .add(base + row_index * size_of::<RowDescriptor<ParamLayout64>>())
-                    as *const RowDescriptor<ParamLayout64>);
-                Some(desc.data_offset())
-            } else {
-                let desc = &*(self
-                    .as_ptr()
-                    .add(base + row_index * size_of::<RowDescriptor<ParamLayout32>>())
-                    as *const RowDescriptor<ParamLayout32>);
-                Some(desc.data_offset())
-            }
+        if self.is_64_bit() {
+            self.row_descriptors::<u64>()
+                .get(row_index)
+                .map(|d| (d.id, d.data_offset()))
+        } else {
+            self.row_descriptors::<u32>()
+                .get(row_index)
+                .map(|d| (d.id, d.data_offset()))
         }
     }
-}
 
-#[repr(C)]
-struct ParamHeader {
-    strings_offset: u32,
-    short_data_offset: u16,
-    unk_06: u16,
-    paramdef_data_version: u16,
-    row_count: u16,
-    struct_name: ParamStructName,
-    big_endian: u8,
-    format_2d: u8,
-    format_2e: u8,
-}
-
-impl ParamHeader {
     /// Whether param type is stored as an offset (bit 7 of format_2d).
     const fn has_offset_param_type(&self) -> bool {
         (self.format_2d & 0x80) != 0
@@ -399,39 +483,4 @@ struct ParamStructNameOffset {
     _pad: u32,
     value: u32,
     _reserved: [u32; 6],
-}
-
-/// Traits for compile-time encoding of param file layout variations.
-mod param_layout {
-    use std::mem::size_of;
-
-    /// Trait for offset size variations in param files.
-    ///
-    /// # Safety
-    ///
-    /// Implementors must assure that the associated `FileOffsetType` correctly
-    /// represents param file row descriptor offset sizes.
-    pub unsafe trait ParamLayout: Copy {
-        type FileOffsetType: Into<u64> + Copy;
-
-        fn is_64_bit() -> bool {
-            size_of::<Self::FileOffsetType>() == 8
-        }
-    }
-
-    /// Marker for 32-bit offsets (12-byte row descriptors).
-    #[derive(Clone, Copy)]
-    pub struct ParamLayout32;
-
-    unsafe impl ParamLayout for ParamLayout32 {
-        type FileOffsetType = u32;
-    }
-
-    /// Marker for 64-bit offsets (24-byte row descriptors).
-    #[derive(Clone, Copy)]
-    pub struct ParamLayout64;
-
-    unsafe impl ParamLayout for ParamLayout64 {
-        type FileOffsetType = u64;
-    }
 }

--- a/crates/eldenring/src/rva/bundle.rs
+++ b/crates/eldenring/src/rva/bundle.rs
@@ -4,7 +4,7 @@
 
 /// A struct containing offsets (relative to the beginning of the executable) of
 /// various addresses of structures and functions. They can be converted to a
-/// usable address using the [Pe::rva_to_va](pelite::Pe::rva_to_va) trait function
+/// usable address using the [Pe::rva_to_va](pelite::pe64::Pe::rva_to_va) trait function
 /// of [Program](fromsoftware_shared::Program).
 ///
 /// These are populated from `mapper-profile.toml` in the root of this package
@@ -88,6 +88,7 @@ pub struct RvaBundle {
     pub param_res_cap_vmt: u32,
     pub player_ins_vmt: u32,
     pub register_task: u32,
+    pub solo_param_repository_vmt: u32,
     pub spawn_geometry: u32,
     pub world_area_chr_base_vmt: u32,
     pub world_area_chr_vmt: u32,

--- a/crates/eldenring/src/rva/rva_jp.rs
+++ b/crates/eldenring/src/rva/rva_jp.rs
@@ -87,6 +87,7 @@ pub const RVAS: RvaBundle = RvaBundle {
     param_res_cap_vmt: 0x2baf908,
     player_ins_vmt: 0x2a7cb40,
     register_task: 0xeb1f40,
+    solo_param_repository_vmt: 0x2bb53a8,
     spawn_geometry: 0x6a5080,
     world_area_chr_base_vmt: 0x2a4c1a0,
     world_area_chr_vmt: 0x2a4c0f0,

--- a/crates/eldenring/src/rva/rva_ww.rs
+++ b/crates/eldenring/src/rva/rva_ww.rs
@@ -87,6 +87,7 @@ pub const RVAS: RvaBundle = RvaBundle {
     param_res_cap_vmt: 0x2baf908,
     player_ins_vmt: 0x2a7cb40,
     register_task: 0xeb2000,
+    solo_param_repository_vmt: 0x2bb53a8,
     spawn_geometry: 0x6a5150,
     world_area_chr_base_vmt: 0x2a4c1a0,
     world_area_chr_vmt: 0x2a4c0f0,


### PR DESCRIPTION
This is in preparation for porting this code to Sekiro. This adds documentation, improves a few names, and removes some unnecessary complexity. It consistently hides the details of how rows are located, and so presents a more unified API for ParamFile.

Although I considered removing some of the indirection and defensive programming around parameter location that's not necessary for vanilla Elden Ring, as discussed offline the consensus is to keep it for now.