### PR TITLE
[ER] Fixed a bug where param row iteration returned internal row indices.

### DIFF
--- a/crates/eldenring/src/fd4/param_repository.rs
+++ b/crates/eldenring/src/fd4/param_repository.rs
@@ -320,7 +320,7 @@ impl ParamFile {
     pub unsafe fn rows<'a, P: ParamDef + 'a>(&'a self) -> impl Iterator<Item = (u32, &'a P)> + 'a {
         self.lookup_table()
             .iter()
-            .map(|l| unsafe { (l.index, self.get_row_by_index(l.index as usize).unwrap()) })
+            .map(|l| unsafe { (l.param_id, self.get_row_by_index(l.index as usize).unwrap()) })
     }
 
     /// Returns an iterator over each mutable row in this file along with their
@@ -350,10 +350,13 @@ impl ParamFile {
             // be `end` at this point. We know `file` is valid because of that
             // same reference.
             unsafe {
-                let index = ptr.as_ref().unwrap().index;
-                let result = file.as_mut().get_row_by_index_mut(index as usize).unwrap();
+                let lookup = ptr.as_ref().unwrap();
+                let result = file
+                    .as_mut()
+                    .get_row_by_index_mut(lookup.index as usize)
+                    .unwrap();
                 ptr = ptr.add(1);
-                Some((index, result))
+                Some((lookup.param_id, result))
             }
         })
     }

--- a/crates/sekiro/src/fd4/param_repository.rs
+++ b/crates/sekiro/src/fd4/param_repository.rs
@@ -262,7 +262,7 @@ impl ParamFile {
     pub unsafe fn rows<'a, P: ParamDef + 'a>(&'a self) -> impl Iterator<Item = (u32, &'a P)> + 'a {
         self.lookup_table()
             .iter()
-            .map(|l| unsafe { (l.index, self.get_row_by_index(l.index as usize).unwrap()) })
+            .map(|l| unsafe { (l.param_id, self.get_row_by_index(l.index as usize).unwrap()) })
     }
 
     /// Returns an iterator over each mutable row in this file, in parameter ID order.
@@ -291,10 +291,13 @@ impl ParamFile {
             // be `end` at this point. We know `file` is valid because of that
             // same reference.
             unsafe {
-                let index = ptr.as_ref().unwrap().index;
-                let result = file.as_mut().get_row_by_index_mut(index as usize).unwrap();
+                let lookup = ptr.as_ref().unwrap();
+                let result = file
+                    .as_mut()
+                    .get_row_by_index_mut(lookup.index as usize)
+                    .unwrap();
                 ptr = ptr.add(1);
-                Some((index, result))
+                Some((lookup.param_id, result))
             }
         })
     }


### PR DESCRIPTION
### Problem
RowLookupEntry stores both:
- `param_id`: the real row ID
- `index`: the row's position in the param file
The iteration APIs are documented as returning parameter IDs in ID order, but they were yielding `index` instead of `param_id`.

That made callers receive values like 0, 1, 2, ... instead of the real row IDs, which breaks any code that relies on the iterator contract.

### Fix
Update `ParamFile::rows()` and `ParamFile::rows_mut()` to return `RowLookupEntry::param_id` while still using index internally to access the row data.

### Impact
This restores the documented behavior of the row iteration APIs and makes them consistent with the rest of the lookup logic, including `find_index()` and `get_row_by_id()`.