### PR TITLE
[codex] Add Elden Ring item helper APIs

### DIFF
--- a/crates/eldenring/src/cs/game_data_man.rs
+++ b/crates/eldenring/src/cs/game_data_man.rs
@@ -1,6 +1,6 @@
 use crate::{
     Vector,
-    cs::{CSGaitemGameData, ChrType, PlayerGameData},
+    cs::{CSGaitemGameData, ChrType, InventoryEditError, ItemId, PlayerGameData},
     fd4::FD4Time,
 };
 use bitfield::bitfield;
@@ -120,6 +120,34 @@ impl FromStatic for GameDataMan {
 
     fn instance_ptr() -> shared::InstanceResult<*mut Self> {
         unsafe { load_static_indirect(crate::rva::get().game_data_man) }
+    }
+}
+
+impl GameDataMan {
+    /// Gives the main player an item by directly editing ER's inventory data.
+    ///
+    /// This is an interim helper for cases where ER's ItemGive path is not
+    /// available. It only supports goods and accessories; weapons, protectors,
+    /// and gems need gaitem instance creation and should be granted through
+    /// [MapItemMan::grant_item](crate::cs::MapItemMan::grant_item).
+    pub fn try_give_inventory_item_directly(
+        &mut self,
+        item: ItemId,
+        quantity: u32,
+    ) -> Result<(), InventoryEditError> {
+        self.main_player_game_data
+            .equipment
+            .equip_inventory_data
+            .try_give_item_directly(item, quantity)
+    }
+
+    /// Removes up to `quantity` instances of `item` from the main player's
+    /// inventory.
+    pub fn remove_inventory_item(&mut self, item: ItemId, quantity: u32) {
+        self.main_player_game_data
+            .equipment
+            .equip_inventory_data
+            .remove_item(item, quantity);
     }
 }
 

--- a/crates/eldenring/src/cs/item.rs
+++ b/crates/eldenring/src/cs/item.rs
@@ -1,4 +1,383 @@
+use std::alloc::{Layout, LayoutError, alloc_zeroed};
+use std::ffi::c_void;
+use std::{fmt, ops, ptr, sync::LazyLock};
+
+use pelite::{pattern, pe64::Pe};
+use shared::{Program, util::IncompleteArrayField};
+use thiserror::Error;
+
+use super::ItemId;
+
+const ITEM_GIVE_PATTERN: &str = "8B 02 83 F8 0A";
+const ITEM_GIVE_PATTERN_OFFSET: u32 = 0x52;
+
+/// The maximum number of entries ER's ItemGive path accepts in one call.
+pub const MAX_ITEMS_PER_GRANT: usize = 10;
+
 #[shared::singleton("MapItemMan")]
 pub struct MapItemMan {
     // TODO: actual data
+}
+
+/// The address for the function call that grants an item to the player with a
+/// visible popup. Callers can use this to hook the function for their needs.
+///
+/// The C signature of this function is:
+///
+/// ```c
+/// void ItemGive(
+///     MapItemMan* man,
+///     ItemBuffer* buffer,
+///     uint64_t unknown0,
+///     bool unknown1,
+///     size_t unknown2,
+///     bool unknown3);
+/// ```
+///
+/// This is currently found by a private AOB lookup rather than a generated RVA
+/// because a stable RVA for the supported executable has not been validated.
+pub static MAP_ITEM_MAN_GRANT_ITEM_VA: LazyLock<u64> = LazyLock::new(|| {
+    map_item_man_grant_item_va().expect("Call target for MAP_ITEM_MAN_GRANT_ITEM_VA was not in exe")
+});
+
+static MAP_ITEM_MAN_GRANT_ITEM_VA_RESULT: LazyLock<Result<u64, String>> =
+    LazyLock::new(|| find_item_give_va().map_err(|err| err.to_string()));
+
+/// An error returned when ER's ItemGive path cannot be called.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum ItemGrantError {
+    /// The executable scan could not find a unique ItemGive function.
+    #[error("{0}")]
+    Lookup(String),
+
+    /// More items were passed than ER accepts in one ItemGive call.
+    #[error("ER ItemGive accepts at most {max} entries per call, got {actual}")]
+    TooManyItems { max: usize, actual: usize },
+}
+
+/// Returns the address of ER's ItemGive function.
+pub fn map_item_man_grant_item_va() -> Result<u64, ItemGrantError> {
+    MAP_ITEM_MAN_GRANT_ITEM_VA_RESULT
+        .as_ref()
+        .copied()
+        .map_err(|err| ItemGrantError::Lookup(err.clone()))
+}
+
+fn find_item_give_va() -> Result<u64, String> {
+    let scanner_pattern = pattern::parse(ITEM_GIVE_PATTERN)
+        .map_err(|_| "failed to parse ER ItemGive AOB pattern".to_string())?;
+    let program = Program::current();
+    let mut matches = program.scanner().matches_code(&scanner_pattern);
+    let mut captures = [0u32; 1];
+    if !matches.next(&mut captures) {
+        return Err("could not find ER ItemGive function in executable".to_string());
+    }
+
+    let mut duplicate = [0u32; 1];
+    if matches.next(&mut duplicate) {
+        return Err("ER ItemGive AOB pattern matched more than one function".to_string());
+    }
+
+    let rva = captures[0]
+        .checked_sub(ITEM_GIVE_PATTERN_OFFSET)
+        .ok_or("ER ItemGive AOB match appeared before expected function start")?;
+    program
+        .rva_to_va(rva)
+        .map_err(|err| format!("failed to convert ER ItemGive RVA {rva:#x}: {err:?}"))
+}
+
+impl MapItemMan {
+    /// Grants the player the single `item`, with an on-screen pop-up indicating
+    /// that they received it.
+    ///
+    /// Panics if ER's ItemGive function cannot be found or called. Use
+    /// [try_grant_item](Self::try_grant_item) to handle lookup failure.
+    pub fn grant_item(&mut self, item: impl Into<ItemBufferEntry>) {
+        self.try_grant_item(item)
+            .expect("failed to grant item through ER ItemGive")
+    }
+
+    /// Grants the player the single `item`, with an on-screen pop-up indicating
+    /// that they received it.
+    pub fn try_grant_item(
+        &mut self,
+        item: impl Into<ItemBufferEntry>,
+    ) -> Result<(), ItemGrantError> {
+        let array = ItemArray::new([item.into()]);
+        self.try_grant_items(&array)
+    }
+
+    /// Grants the player the given `items`, with an on-screen pop-up indicating
+    /// that they received them.
+    ///
+    /// Panics if ER's ItemGive function cannot be found or called. Use
+    /// [try_grant_items](Self::try_grant_items) to handle lookup failure.
+    pub fn grant_items(&mut self, items: impl AsRef<ItemBuffer>) {
+        self.try_grant_items(items)
+            .expect("failed to grant items through ER ItemGive")
+    }
+
+    /// Grants the player the given `items`, with an on-screen pop-up indicating
+    /// that they received them.
+    pub fn try_grant_items(&mut self, items: impl AsRef<ItemBuffer>) -> Result<(), ItemGrantError> {
+        let items = items.as_ref();
+        let len = items.len();
+        if len > MAX_ITEMS_PER_GRANT {
+            return Err(ItemGrantError::TooManyItems {
+                max: MAX_ITEMS_PER_GRANT,
+                actual: len,
+            });
+        }
+
+        let grant_items: unsafe extern "C" fn(
+            *mut c_void,
+            *const ItemBuffer,
+            u64,
+            bool,
+            usize,
+            bool,
+        ) = unsafe { std::mem::transmute(map_item_man_grant_item_va()?) };
+
+        unsafe {
+            grant_items(self as *mut Self as *mut c_void, items, 0, false, 0, false);
+        }
+        Ok(())
+    }
+}
+
+/// A set of items granted to the player.
+#[repr(C)]
+pub struct ItemBuffer {
+    /// The number of items granted.
+    length: u32,
+
+    /// Information about the items themselves.
+    items: IncompleteArrayField<ItemBufferEntry>,
+}
+
+impl ItemBuffer {
+    /// Creates a new ItemBuffer with the given length.
+    ///
+    /// The returned buffer's entries begin zeroed out.
+    pub fn new(length: u32) -> Box<Self> {
+        let layout = Self::layout(length.try_into().unwrap()).unwrap();
+        // Safety: We're allocating directly from the standard allocator into a
+        // Box.
+        let mut buffer = unsafe { Box::from_raw(alloc_zeroed(layout) as *mut ItemBuffer) };
+        buffer.length = length;
+        buffer
+    }
+
+    /// Returns the memory layout for an [ItemBuffer] with the given number of
+    /// elements.
+    fn layout(length: usize) -> Result<Layout, LayoutError> {
+        let layout = Layout::new::<ItemBuffer>();
+        let (layout, _) = layout.extend(Layout::array::<ItemBufferEntry>(length)?)?;
+        Ok(layout.pad_to_align())
+    }
+
+    /// Returns the number of entries in the buffer.
+    pub fn len(&self) -> usize {
+        self.length.try_into().unwrap()
+    }
+
+    /// Returns whether the buffer has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+
+    /// Returns the list of items in the buffer as a slice.
+    pub fn as_slice(&self) -> &[ItemBufferEntry] {
+        // Safety: We trust the game to report lengths accurately.
+        unsafe { self.items.as_slice(self.len()) }
+    }
+
+    /// Returns the list of items in the buffer as a mutable slice.
+    pub fn as_mut_slice(&mut self) -> &mut [ItemBufferEntry] {
+        // Safety: We trust the game to report lengths accurately.
+        unsafe { self.items.as_mut_slice(self.len()) }
+    }
+
+    /// Removes the entry at `index` from the buffer, shifting all elements
+    /// after it to the left.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `index` is out-of-bounds.
+    pub fn remove(&mut self, index: usize) -> ItemBufferEntry {
+        let len = self.length as usize;
+        if index >= len {
+            panic!("removal index (is {index}) should be < len (is {len})");
+        }
+
+        // Implementation copied from Rust's Vec.
+        unsafe {
+            // infallible
+            let ret;
+            {
+                // the place we are taking from.
+                let ptr = self.as_mut_ptr().add(index);
+                // copy it out, unsafely having a copy of the value on
+                // the stack and in the vector at the same time.
+                ret = ptr::read(ptr);
+
+                // Shift everything down to fill in that spot.
+                ptr::copy(ptr.add(1), ptr, len - index - 1);
+            }
+            self.length = (len - 1) as u32;
+            ret
+        }
+    }
+}
+
+impl From<&[ItemBufferEntry]> for Box<ItemBuffer> {
+    fn from(items: &[ItemBufferEntry]) -> Box<ItemBuffer> {
+        let mut buffer = ItemBuffer::new(items.len().try_into().unwrap());
+        buffer.as_mut_slice().clone_from_slice(items);
+        buffer
+    }
+}
+
+impl ops::Deref for ItemBuffer {
+    type Target = [ItemBufferEntry];
+
+    fn deref(&self) -> &[ItemBufferEntry] {
+        self.as_slice()
+    }
+}
+
+impl ops::DerefMut for ItemBuffer {
+    fn deref_mut(&mut self) -> &mut [ItemBufferEntry] {
+        self.as_mut_slice()
+    }
+}
+
+impl fmt::Debug for ItemBuffer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        self.as_slice().fmt(f)
+    }
+}
+
+/// A single item granted to the player.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ItemBufferEntry {
+    /// The ID of the item that was granted.
+    pub id: ItemId,
+
+    /// The number of this item that the player received.
+    pub quantity: u32,
+
+    /// Legacy durability field. -1 means full durability.
+    pub legacy_durability: i32,
+
+    /// Unused by ER's ItemGive path.
+    pub unused: u32,
+}
+
+impl ItemBufferEntry {
+    /// Creates an [ItemBufferEntry] containing `quantity` full-durability items
+    /// with this ID.
+    pub fn new(id: ItemId, quantity: u32) -> Self {
+        Self {
+            id,
+            quantity,
+            legacy_durability: -1,
+            unused: 0,
+        }
+    }
+}
+
+impl From<ItemId> for ItemBufferEntry {
+    /// Creates an [ItemBufferEntry] containing a single full-durability item
+    /// with this ID.
+    fn from(id: ItemId) -> ItemBufferEntry {
+        ItemBufferEntry::new(id, 1)
+    }
+}
+
+/// A fixed-size type whose references are convertible to [ItemBuffer], so it
+/// can be stack-allocated.
+#[repr(C)]
+pub struct ItemArray<const N: usize> {
+    /// The number of items granted.
+    length: u32,
+
+    /// Information about the items themselves.
+    pub items: [ItemBufferEntry; N],
+}
+
+impl<const N: usize> ItemArray<N> {
+    /// Creates a new fixed-size item buffer with the given contents.
+    #[inline]
+    pub fn new(items: [ItemBufferEntry; N]) -> Self {
+        ItemArray {
+            length: N.try_into().unwrap(),
+            items,
+        }
+    }
+}
+
+impl<const N: usize> fmt::Debug for ItemArray<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        self.items.fmt(f)
+    }
+}
+
+impl<const N: usize> AsRef<ItemBuffer> for ItemArray<N> {
+    fn as_ref(&self) -> &ItemBuffer {
+        let pointer: *const ItemArray<N> = ptr::from_ref(self);
+
+        // Safety: We know the pointer is valid because we just created it, and
+        // ItemArray is defined to have a valid memory layout for ItemBuffer.
+        // The unbounded lifetime we create here is cast to the narrower self
+        // lifetime upon return.
+        unsafe { &*(pointer as *const ItemBuffer) }
+    }
+}
+
+impl<const N: usize> AsMut<ItemBuffer> for ItemArray<N> {
+    fn as_mut(&mut self) -> &mut ItemBuffer {
+        let pointer: *mut ItemArray<N> = ptr::from_mut(self);
+
+        // Safety: See the AsRef implementation above.
+        unsafe { &mut *(pointer as *mut ItemBuffer) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::{offset_of, size_of};
+
+    use super::*;
+    use crate::cs::ItemCategory;
+
+    #[test]
+    fn item_give_layout_matches_er_buffer() {
+        assert_eq!(size_of::<ItemBufferEntry>(), 0x10);
+        assert_eq!(offset_of!(ItemBuffer, items), 0x4);
+        assert_eq!(offset_of!(ItemArray<1>, items), 0x4);
+    }
+
+    #[test]
+    fn item_entry_defaults_to_full_legacy_durability() {
+        let id = ItemId::new(ItemCategory::Goods, 100).unwrap();
+        let entry = ItemBufferEntry::from(id);
+
+        assert_eq!(entry.id, id);
+        assert_eq!(entry.quantity, 1);
+        assert_eq!(entry.legacy_durability, -1);
+        assert_eq!(entry.unused, 0);
+    }
+
+    #[test]
+    fn item_array_references_as_item_buffer() {
+        let id = ItemId::new(ItemCategory::Goods, 100).unwrap();
+        let array = ItemArray::new([ItemBufferEntry::new(id, 3)]);
+        let buffer = array.as_ref();
+
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(buffer.as_slice()[0].id, id);
+        assert_eq!(buffer.as_slice()[0].quantity, 3);
+    }
 }

--- a/crates/eldenring/src/cs/item.rs
+++ b/crates/eldenring/src/cs/item.rs
@@ -25,13 +25,7 @@ pub struct MapItemMan {
 /// The C signature of this function is:
 ///
 /// ```c
-/// void ItemGive(
-///     MapItemMan* man,
-///     ItemBuffer* buffer,
-///     uint64_t unknown0,
-///     bool unknown1,
-///     size_t unknown2,
-///     bool unknown3);
+/// void ItemGive(MapItemMan* man, ItemBuffer* buffer, ItemGrantCallData* data, uint32_t flags);
 /// ```
 ///
 /// This is currently found by a private AOB lookup rather than a generated RVA
@@ -129,17 +123,21 @@ impl MapItemMan {
             });
         }
 
+        let mut data = ItemGrantCallData::new(items.as_slice());
         let grant_items: unsafe extern "C" fn(
             *mut c_void,
             *const ItemBuffer,
-            u64,
-            bool,
-            usize,
-            bool,
+            *mut ItemGrantCallData<MAX_ITEMS_PER_GRANT>,
+            u32,
         ) = unsafe { std::mem::transmute(map_item_man_grant_item_va()?) };
 
         unsafe {
-            grant_items(self as *mut Self as *mut c_void, items, 0, false, 0, false);
+            grant_items(
+                self as *mut Self as *mut c_void,
+                data.buffer.as_ref(),
+                &mut data,
+                0,
+            );
         }
         Ok(())
     }
@@ -268,11 +266,11 @@ pub struct ItemBufferEntry {
     /// The number of this item that the player received.
     pub quantity: u32,
 
-    /// Legacy durability field. -1 means full durability.
-    pub legacy_durability: i32,
+    /// Legacy durability field. `u32::MAX` means full durability.
+    pub durability: u32,
 
-    /// Unused by ER's ItemGive path.
-    pub unused: u32,
+    /// Gem or Ash of War field. `u32::MAX` means no gem.
+    pub gem: u32,
 }
 
 impl ItemBufferEntry {
@@ -282,8 +280,17 @@ impl ItemBufferEntry {
         Self {
             id,
             quantity,
-            legacy_durability: -1,
-            unused: 0,
+            durability: u32::MAX,
+            gem: u32::MAX,
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            id: ItemId::try_from(0).expect("weapon 0 should be a valid item ID"),
+            quantity: 0,
+            durability: u32::MAX,
+            gem: u32::MAX,
         }
     }
 }
@@ -314,6 +321,33 @@ impl<const N: usize> ItemArray<N> {
         ItemArray {
             length: N.try_into().unwrap(),
             items,
+        }
+    }
+
+    fn with_length(items: [ItemBufferEntry; N], length: usize) -> Self {
+        assert!(length <= N);
+        ItemArray {
+            length: length.try_into().unwrap(),
+            items,
+        }
+    }
+}
+
+#[repr(C)]
+struct ItemGrantCallData<const N: usize> {
+    scratch: [u8; 0x20],
+    buffer: ItemArray<N>,
+}
+
+impl ItemGrantCallData<MAX_ITEMS_PER_GRANT> {
+    fn new(items: &[ItemBufferEntry]) -> Self {
+        assert!(items.len() <= MAX_ITEMS_PER_GRANT);
+
+        let mut buffer_items = [ItemBufferEntry::empty(); MAX_ITEMS_PER_GRANT];
+        buffer_items[..items.len()].copy_from_slice(items);
+        Self {
+            scratch: [0; 0x20],
+            buffer: ItemArray::with_length(buffer_items, items.len()),
         }
     }
 }
@@ -366,8 +400,8 @@ mod tests {
 
         assert_eq!(entry.id, id);
         assert_eq!(entry.quantity, 1);
-        assert_eq!(entry.legacy_durability, -1);
-        assert_eq!(entry.unused, 0);
+        assert_eq!(entry.durability, u32::MAX);
+        assert_eq!(entry.gem, u32::MAX);
     }
 
     #[test]
@@ -376,6 +410,18 @@ mod tests {
         let array = ItemArray::new([ItemBufferEntry::new(id, 3)]);
         let buffer = array.as_ref();
 
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(buffer.as_slice()[0].id, id);
+        assert_eq!(buffer.as_slice()[0].quantity, 3);
+    }
+
+    #[test]
+    fn item_grant_call_data_matches_er_call_frame() {
+        let id = ItemId::new(ItemCategory::Goods, 100).unwrap();
+        let data = ItemGrantCallData::new(&[ItemBufferEntry::new(id, 3)]);
+        let buffer = data.buffer.as_ref();
+
+        assert_eq!(offset_of!(ItemGrantCallData<1>, buffer), 0x20);
         assert_eq!(buffer.len(), 1);
         assert_eq!(buffer.as_slice()[0].id, id);
         assert_eq!(buffer.as_slice()[0].quantity, 3);

--- a/crates/eldenring/src/cs/player_game_data.rs
+++ b/crates/eldenring/src/cs/player_game_data.rs
@@ -10,7 +10,9 @@ use crate::{
 };
 use shared::{IsEmpty, MaybeEmpty, NonEmptyIteratorExt, NonEmptyIteratorMutExt, OwnedPtr};
 
-use crate::cs::{FieldInsHandle, GaitemHandle, ItemId, OptionalItemId};
+use crate::cs::{
+    FieldInsHandle, GaitemCategory, GaitemHandle, ItemCategory, ItemId, OptionalItemId,
+};
 
 #[repr(C)]
 /// Source of name: RTTI
@@ -552,6 +554,19 @@ impl InventoryItemsData {
         }
     }
 
+    /// A mutable slice over all the normal item [EquipInventoryDataListEntry]
+    /// slots allocated for this [InventoryItemsData].
+    pub fn normal_entries_capacity_mut(
+        &mut self,
+    ) -> &mut [MaybeEmpty<EquipInventoryDataListEntry>] {
+        unsafe {
+            std::slice::from_raw_parts_mut(
+                self.normal_items_head.as_ptr(),
+                self.normal_items_capacity as usize,
+            )
+        }
+    }
+
     /// Whether there's no more room left in the normal items inventory and
     /// picking up a new item will fail.
     pub fn is_normal_items_full(&self) -> bool {
@@ -672,6 +687,210 @@ pub struct EquipInventoryData {
     unk122: u8,
     unk123: u8,
     unk124: u32,
+}
+
+/// An error returned when directly editing ER's inventory data.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum InventoryEditError {
+    /// This category needs gaitem instance creation, so callers should use
+    /// [MapItemMan::grant_item](crate::cs::MapItemMan::grant_item) instead.
+    #[error(
+        "direct ER inventory grants do not support {0:?}; this category needs a game item-creation path"
+    )]
+    UnsupportedItemCategory(ItemCategory),
+
+    /// No empty normal inventory slot was available for the new item.
+    #[error("ER inventory is full; could not grant {item:?}")]
+    InventoryFull { item: ItemId },
+}
+
+impl EquipInventoryData {
+    /// Returns whether `item` can be given by directly editing
+    /// [EquipInventoryData].
+    ///
+    /// Only goods and accessories are supported. Weapons, protectors, and gems
+    /// need gaitem instances that this helper cannot synthesize.
+    pub fn can_give_item_directly(item: ItemId) -> bool {
+        matches!(
+            item.category(),
+            ItemCategory::Accessory | ItemCategory::Goods
+        )
+    }
+
+    /// Gives an item by directly editing the main inventory data.
+    ///
+    /// This is an interim helper for cases where ER's ItemGive path is not
+    /// available. It intentionally rejects item categories that need synthesized
+    /// gaitem instances; use [MapItemMan::grant_item](crate::cs::MapItemMan::grant_item)
+    /// for those categories.
+    pub fn try_give_item_directly(
+        &mut self,
+        item: ItemId,
+        quantity: u32,
+    ) -> Result<(), InventoryEditError> {
+        if quantity == 0 {
+            return Ok(());
+        }
+
+        if !Self::can_give_item_directly(item) {
+            return Err(InventoryEditError::UnsupportedItemCategory(item.category()));
+        }
+
+        if try_stack_inventory_item(self.items_data.items_mut(), item, quantity) {
+            return Ok(());
+        }
+
+        let normal_entries = unsafe {
+            std::slice::from_raw_parts_mut(
+                self.items_data.normal_items_head.as_ptr(),
+                self.items_data.normal_items_capacity as usize,
+            )
+        };
+
+        append_normal_inventory_item(
+            normal_entries,
+            &mut self.items_data.normal_items_len,
+            &mut self.total_item_entry_count,
+            &mut self.next_sort_id,
+            item,
+            quantity,
+        )
+    }
+
+    /// Removes up to `quantity` instances of `item` from inventory.
+    ///
+    /// Empty slots are cleared using ER's sentinel representation for
+    /// [MaybeEmpty<EquipInventoryDataListEntry>].
+    pub fn remove_item(&mut self, item: ItemId, quantity: u32) {
+        let mut remaining = quantity;
+        let mut cleared = 0;
+
+        cleared += remove_inventory_item_from_slots(
+            self.items_data.current_key_entries_mut(),
+            item,
+            &mut remaining,
+        );
+        if remaining > 0 {
+            cleared += remove_inventory_item_from_slots(
+                self.items_data.normal_entries_mut(),
+                item,
+                &mut remaining,
+            );
+        }
+
+        self.total_item_entry_count = self.total_item_entry_count.saturating_sub(cleared);
+    }
+}
+
+fn try_stack_inventory_item<'a>(
+    entries: impl Iterator<Item = &'a mut EquipInventoryDataListEntry>,
+    item: ItemId,
+    quantity: u32,
+) -> bool {
+    for entry in entries {
+        if entry.item_id == item && entry.quantity > 0 {
+            entry.quantity = entry.quantity.saturating_add(quantity);
+            entry.is_new = true;
+            return true;
+        }
+    }
+
+    false
+}
+
+fn append_normal_inventory_item(
+    entries: &mut [MaybeEmpty<EquipInventoryDataListEntry>],
+    normal_items_len: &mut u32,
+    total_item_entry_count: &mut u32,
+    next_sort_id: &mut u32,
+    item: ItemId,
+    quantity: u32,
+) -> Result<(), InventoryEditError> {
+    let Some((index, slot)) = entries
+        .iter_mut()
+        .enumerate()
+        .find(|(_, entry)| entry.is_empty())
+    else {
+        return Err(InventoryEditError::InventoryFull { item });
+    };
+
+    let sort_id = *next_sort_id;
+    *next_sort_id = (*next_sort_id).saturating_add(1);
+
+    *slot = MaybeEmpty::new(EquipInventoryDataListEntry {
+        gaitem_handle: gaitem_handle_for(item),
+        item_id: item,
+        quantity,
+        sort_id,
+        is_new: true,
+        pot_group: -1,
+    });
+
+    if index >= *normal_items_len as usize {
+        *normal_items_len = index as u32 + 1;
+    }
+    *total_item_entry_count = total_item_entry_count.saturating_add(1);
+
+    Ok(())
+}
+
+fn remove_inventory_item_from_slots(
+    slots: &mut [MaybeEmpty<EquipInventoryDataListEntry>],
+    item: ItemId,
+    remaining: &mut u32,
+) -> u32 {
+    let mut cleared = 0;
+
+    for slot in slots {
+        if *remaining == 0 {
+            break;
+        }
+
+        let should_clear = {
+            let Some(entry) = slot.as_option_mut() else {
+                continue;
+            };
+            if entry.item_id != item || entry.quantity == 0 {
+                continue;
+            }
+
+            if entry.quantity > *remaining {
+                entry.quantity -= *remaining;
+                *remaining = 0;
+                false
+            } else {
+                *remaining -= entry.quantity;
+                true
+            }
+        };
+
+        if should_clear {
+            clear_inventory_slot(slot);
+            cleared += 1;
+        }
+    }
+
+    cleared
+}
+
+fn clear_inventory_slot(slot: &mut MaybeEmpty<EquipInventoryDataListEntry>) {
+    unsafe {
+        std::ptr::write_bytes(slot.as_non_null().as_ptr(), 0xff, 1);
+    }
+    debug_assert!(slot.is_empty());
+}
+
+fn gaitem_handle_for(item: ItemId) -> GaitemHandle {
+    GaitemHandle::from_parts(
+        item.param_id(),
+        match item.category() {
+            ItemCategory::Weapon => GaitemCategory::Weapon,
+            ItemCategory::Protector => GaitemCategory::Protector,
+            ItemCategory::Accessory => GaitemCategory::Accessory,
+            ItemCategory::Goods => GaitemCategory::Goods,
+            ItemCategory::Gem => GaitemCategory::Gem,
+        },
+    )
 }
 
 bitfield! {
@@ -901,6 +1120,7 @@ pub enum EquipmentDurabilityStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::mem::MaybeUninit;
 
     #[test]
     fn test_item_id_mapping() {
@@ -914,5 +1134,167 @@ mod tests {
             ((mapping.bits4.0 >> 12) & 0xFFF) - 1
         );
         assert_eq!(mapping.item_slot(), mapping.bits4.0 & 0xFFF);
+    }
+
+    #[test]
+    fn direct_inventory_grant_rejects_categories_needing_gaitem_instances() {
+        assert!(!EquipInventoryData::can_give_item_directly(
+            ItemId::new(ItemCategory::Weapon, 1000).unwrap()
+        ));
+        assert!(!EquipInventoryData::can_give_item_directly(
+            ItemId::new(ItemCategory::Protector, 40000).unwrap()
+        ));
+        assert!(!EquipInventoryData::can_give_item_directly(
+            ItemId::new(ItemCategory::Gem, 1000).unwrap()
+        ));
+        assert!(EquipInventoryData::can_give_item_directly(
+            ItemId::new(ItemCategory::Goods, 100).unwrap()
+        ));
+        assert!(EquipInventoryData::can_give_item_directly(
+            ItemId::new(ItemCategory::Accessory, 1000).unwrap()
+        ));
+    }
+
+    #[test]
+    fn direct_inventory_grant_allocates_normal_slot() {
+        let existing = ItemId::new(ItemCategory::Goods, 100).unwrap();
+        let granted = ItemId::new(ItemCategory::Goods, 200).unwrap();
+        let mut entries = [
+            filled_inventory_slot(existing, 1),
+            empty_inventory_slot(),
+            empty_inventory_slot(),
+        ];
+        let mut normal_items_len = 1;
+        let mut total_item_entry_count = 1;
+        let mut next_sort_id = 7;
+
+        append_normal_inventory_item(
+            &mut entries,
+            &mut normal_items_len,
+            &mut total_item_entry_count,
+            &mut next_sort_id,
+            granted,
+            4,
+        )
+        .unwrap();
+
+        let entry = entries[1].as_option().unwrap();
+        assert_eq!(entry.item_id, granted);
+        assert_eq!(entry.quantity, 4);
+        assert_eq!(entry.sort_id, 7);
+        assert!(entry.is_new);
+        assert_eq!(entry.pot_group, -1);
+        assert_eq!(entry.gaitem_handle.selector(), granted.param_id());
+        assert_eq!(
+            entry.gaitem_handle.category().unwrap(),
+            GaitemCategory::Goods
+        );
+        assert_eq!(normal_items_len, 2);
+        assert_eq!(total_item_entry_count, 2);
+        assert_eq!(next_sort_id, 8);
+    }
+
+    #[test]
+    fn direct_inventory_grant_reports_full_inventory_without_advancing_sort_id() {
+        let existing = ItemId::new(ItemCategory::Goods, 100).unwrap();
+        let granted = ItemId::new(ItemCategory::Goods, 200).unwrap();
+        let mut entries = [
+            filled_inventory_slot(existing, 1),
+            filled_inventory_slot(existing, 2),
+        ];
+        let mut normal_items_len = 2;
+        let mut total_item_entry_count = 2;
+        let mut next_sort_id = 7;
+
+        let result = append_normal_inventory_item(
+            &mut entries,
+            &mut normal_items_len,
+            &mut total_item_entry_count,
+            &mut next_sort_id,
+            granted,
+            4,
+        );
+
+        assert_eq!(
+            result,
+            Err(InventoryEditError::InventoryFull { item: granted })
+        );
+        assert_eq!(normal_items_len, 2);
+        assert_eq!(total_item_entry_count, 2);
+        assert_eq!(next_sort_id, 7);
+    }
+
+    #[test]
+    fn direct_inventory_grant_updates_existing_stack() {
+        let id = ItemId::new(ItemCategory::Goods, 100).unwrap();
+        let mut entry = EquipInventoryDataListEntry {
+            gaitem_handle: gaitem_handle_for(id),
+            item_id: id,
+            quantity: 2,
+            sort_id: 3,
+            is_new: false,
+            pot_group: -1,
+        };
+
+        assert!(try_stack_inventory_item(std::iter::once(&mut entry), id, 5));
+        assert_eq!(entry.quantity, 7);
+        assert!(entry.is_new);
+        assert_eq!(entry.sort_id, 3);
+    }
+
+    #[test]
+    fn inventory_remove_decrements_stack_without_clearing_slot() {
+        let id = ItemId::new(ItemCategory::Goods, 100).unwrap();
+        let mut entries = [filled_inventory_slot(id, 5)];
+        let mut remaining = 2;
+
+        let cleared = remove_inventory_item_from_slots(&mut entries, id, &mut remaining);
+
+        let entry = entries[0].as_option().unwrap();
+        assert_eq!(cleared, 0);
+        assert_eq!(remaining, 0);
+        assert_eq!(entry.quantity, 3);
+    }
+
+    #[test]
+    fn inventory_remove_clears_consumed_slots_with_empty_sentinel() {
+        let id = ItemId::new(ItemCategory::Goods, 100).unwrap();
+        let other = ItemId::new(ItemCategory::Goods, 200).unwrap();
+        let mut entries = [
+            filled_inventory_slot(id, 2),
+            filled_inventory_slot(id, 1),
+            filled_inventory_slot(other, 1),
+        ];
+        let mut remaining = 2;
+
+        let cleared = remove_inventory_item_from_slots(&mut entries, id, &mut remaining);
+
+        assert_eq!(cleared, 1);
+        assert_eq!(remaining, 0);
+        assert!(entries[0].is_empty());
+        assert_eq!(entries[1].as_option().unwrap().quantity, 1);
+        assert_eq!(entries[2].as_option().unwrap().item_id, other);
+    }
+
+    fn empty_inventory_slot() -> MaybeEmpty<EquipInventoryDataListEntry> {
+        let mut slot = MaybeUninit::<MaybeEmpty<EquipInventoryDataListEntry>>::uninit();
+        unsafe {
+            std::ptr::write_bytes(slot.as_mut_ptr(), 0xff, 1);
+            slot.assume_init()
+        }
+    }
+
+    fn filled_inventory_slot(
+        item: ItemId,
+        quantity: u32,
+    ) -> MaybeEmpty<EquipInventoryDataListEntry> {
+        MaybeEmpty::new(EquipInventoryDataListEntry {
+            gaitem_handle: gaitem_handle_for(item),
+            item_id: item,
+            quantity,
+            sort_id: 0,
+            is_new: false,
+            pot_group: -1,
+        })
     }
 }

--- a/crates/eldenring/src/cs/player_game_data.rs
+++ b/crates/eldenring/src/cs/player_game_data.rs
@@ -760,7 +760,7 @@ impl EquipInventoryData {
     /// Removes up to `quantity` instances of `item` from inventory.
     ///
     /// Empty slots are cleared using ER's sentinel representation for
-    /// [MaybeEmpty<EquipInventoryDataListEntry>].
+    /// [`MaybeEmpty<EquipInventoryDataListEntry>`].
     pub fn remove_item(&mut self, item: ItemId, quantity: u32) {
         let mut remaining = quantity;
         let mut cleared = 0;


### PR DESCRIPTION
## Summary

- add Elden Ring item helper APIs and call-frame support
- fix an Elden Ring inventory rustdoc warning so the Rust workflow can pass with warnings denied

## Validation

- cargo fmt -- --check
- cargo build --tests --profile ci --verbose
- cargo test --profile ci --lib --tests --bins --verbose
- cargo clippy --profile ci --all-targets --no-deps
- cargo doc --no-deps