### PR TITLE
Reduce EzStateEnvironmentQuery args to 6 from 7 and remove imaginary fields from EzStateEvent

### DIFF
--- a/crates/eldenring/src/ez_state/environment_query.rs
+++ b/crates/eldenring/src/ez_state/environment_query.rs
@@ -9,15 +9,14 @@ use crate::{
 
 #[repr(C)]
 /// Holds the arguments for an invocation of an ESD query (i.e. a function call that returns a
-/// value). This contains between 1 and 8 values, since the ID is at index 0 and there is a maximum
-/// capacity of 7 arguments.
+/// value). There is a maximum capacity of 6 arguments.
 ///
 /// Source of name: RTTI
 pub struct EzStateEnvironmentQuery {
     vftable: usize,
     arity: u32,
     id: EzStateRawValue,
-    args: [EzStateRawValue; 7],
+    args: [EzStateRawValue; 6],
 }
 
 impl EzStateEnvironmentQuery {
@@ -48,7 +47,6 @@ impl Default for EzStateEnvironmentQuery {
             arity: 1,
             id: EzStateValue::Int32(0).into(),
             args: [
-                EzStateValue::Int32(0).into(),
                 EzStateValue::Int32(0).into(),
                 EzStateValue::Int32(0).into(),
                 EzStateValue::Int32(0).into(),

--- a/crates/eldenring/src/ez_state/event.rs
+++ b/crates/eldenring/src/ez_state/event.rs
@@ -17,8 +17,6 @@ pub struct EzStateEvent {
     vftable: usize,
     pub id: EzStateRawValue,
     pub args: DLFixedVector<EzStateRawValue, 60>,
-    unk3d8: usize,
-    unk3f0: usize,
 }
 
 impl EzStateEvent {
@@ -44,8 +42,6 @@ impl Default for EzStateEvent {
                 .unwrap() as usize,
             id: Default::default(),
             args: Default::default(),
-            unk3d8: 0,
-            unk3f0: 0,
         }
     }
 }


### PR DESCRIPTION
`EzStateEnvironmentQueryImpl` has a maximum of 6 arguments, not 7

The virtual methods are highly arxaned, and I probably mixed up the argument list length and the id field at some point. @axd1x8a found the virtual dtor which shows the struct has a size of 0x80

`140ea9163`

```c++
...
  FUN_142041630(unaff_RDI);
  if ((unaff_RBX & 1) != 0) {
    operator_delete(unaff_RDI,0x80);
  }
...
```

There doesn't appear to be usizes in `EzStateExternalEventTemp` after the argument vector, ctor at `142041030` doesn't initialize them and dtor at `142041130` indicates the size of the struct is 0x3e8.